### PR TITLE
data with null type value break the 'like' filter

### DIFF
--- a/tabulator.js
+++ b/tabulator.js
@@ -915,7 +915,7 @@
 				return self.filterField(row);
 
 			}else{
-				var value = row[self.filterField];
+				var value = (row[self.filterField] !== null) ? row[self.filterField] : '';
 				var term = self.filterValue;
 
 				switch(self.filterType){


### PR DESCRIPTION
value.toLowerCase() failed with "Uncaught TypeError: Cannot read property 'toLowerCase' of null" if dataset has null value in filtered column.