### PR TITLE
New text formatter to prevent HTML injections

### DIFF
--- a/tabulator.js
+++ b/tabulator.js
@@ -4124,6 +4124,11 @@
 		return isNaN(newDate) ? 0 : newDate;
 	},
 
+	//format text to escape html characters
+	_formatText: function(value){
+		return $('<div>').text(value).html();
+	},
+
 	////////////////// Default Sorter/Formatter/Editor Elements //////////////////
 
 	//custom data sorters
@@ -4183,18 +4188,18 @@
 	//custom data formatters
 	formatters:{
 		plaintext:function(value, data, cell, row, options, formatterParams){ //plain text value
-			return value;
+			return this._formatText(value);
 		},
 		textarea:function(value, data, cell, row, options, formatterParams){ //multiline text area
 			cell.css({"white-space":"pre-wrap"});
-			return value;
+			return this._formatText(value);
 		},
 		money:function(value, data, cell, row, options, formatterParams){
 
 			var floatVal = parseFloat(value);
 
 			if(isNaN(floatVal)){
-				return value;
+				return this._formatText(value);
 			}
 
 			var number = floatVal.toFixed(2);
@@ -4213,10 +4218,12 @@
 			return integer + decimal;
 		},
 		email:function(value, data, cell, row, options, formatterParams){
-			return "<a href='mailto:" + value + "'>" + value + "</a>";
+			var formattedEmail = this._formatText(value);
+			return "<a href='mailto:" + formattedEmail + "'>" + formattedEmail + "</a>";
 		},
 		link:function(value, data, cell, row, options, formatterParams){
-			return "<a href='" + value + "'>" + value + "</a>";
+			var formattedLink = this._formatText(value);
+			return "<a href='" + formattedLink + "'>" + formattedLink + "</a>";
 		},
 		tick:function(value, data, cell, row, options, formatterParams){
 			var tick = '<svg enable-background="new 0 0 24 24" height="14" width="14" viewBox="0 0 24 24" xml:space="preserve" ><path fill="#2DC214" clip-rule="evenodd" d="M21.652,3.211c-0.293-0.295-0.77-0.295-1.061,0L9.41,14.34  c-0.293,0.297-0.771,0.297-1.062,0L3.449,9.351C3.304,9.203,3.114,9.13,2.923,9.129C2.73,9.128,2.534,9.201,2.387,9.351  l-2.165,1.946C0.078,11.445,0,11.63,0,11.823c0,0.194,0.078,0.397,0.223,0.544l4.94,5.184c0.292,0.296,0.771,0.776,1.062,1.07  l2.124,2.141c0.292,0.293,0.769,0.293,1.062,0l14.366-14.34c0.293-0.294,0.293-0.777,0-1.071L21.652,3.211z" fill-rule="evenodd"/></svg>';


### PR DESCRIPTION
Hi,

I've added a simple text formatter to prevent HTML code execution. Is known than execution of untrusted HTML code could be dangerous if not correctly sanitized on our project. 

The method used to escape the HTML code is based on jQuery "text" method, which seems to escape the code in a safety way:

`_formatText: function(value){`
` return $('<div>').text(value).html();`
`},`

Here you have two testing pages to check this issue:

- [v2.12 CDN](https://onehdev.neocities.org/tabulator/index2.html)
- [v2.12 with commited changes](https://onehdev.neocities.org/tabulator/index.html)

As you can see on the first example, the HTML code is rendered but the execution of javascript is blocked because of Content-Security-Policy. In my case, when I tested this issue, my CSP allowed to execute the untrusted JS code, adding a security hole that could be abused by malicious users.

In any case, even if CSP blocks the execution of untrusted JS code, a malicious user can execute commands on the same domain. See "IMG Embedded commands" section on [https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet](https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet) for more info.

Hope it be of interest for this awesome plugin!