### PR TITLE
fix for #369

### DIFF
--- a/src/js/extensions/page.js
+++ b/src/js/extensions/page.js
@@ -360,9 +360,16 @@ Page.prototype._getRemotePageAuto = function(){
 
 
 Page.prototype._parseRemoteData = function(data){
-	if(data[this.paginationDataReceivedNames.last_page]){
+	var m = -1;
+	if(typeof this.paginationDataReceivedNames.last_page === 'function'){
+		m = this.paginationDataReceivedNames.last_page(data, this.size);
+	}else if (data[this.paginationDataReceivedNames.last_page]) {
+		m = parseInt(data[this.paginationDataReceivedNames.last_page]);
+	}
+	
+	if(m != -1){
 		if(data[this.paginationDataReceivedNames.data]){
-			this.max = parseInt(data[this.paginationDataReceivedNames.last_page]);
+			this.max = m;
 
 			this.table.rowManager.setData(data[this.paginationDataReceivedNames.data]);
 


### PR DESCRIPTION
added option to configure a function that provides the last page. For example this should work:
paginationDataReceived:{ "last_page": "last" }
and also:
paginationDataReceived:{ "last_page": function(data, pagesize){ return Math.ceil(data.length/pagesize); } }