### PR TITLE
invisible columns / persistentLayout bug

### DIFF
--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -1806,6 +1806,8 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
     //show column
 
     Column.prototype.show = function () {
+      
+      var self = this;
 
       if (!this.visible) {
 
@@ -1837,6 +1839,8 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
     //hide column
 
     Column.prototype.hide = function () {
+      
+      var self = this;
 
       if (this.visible) {
 


### PR DESCRIPTION
hidden colums caused error when "persistentLayout: true".
In my case, the concerned invisible field was an index as well, I did not test if this is important.
(the change should have happened in "src" instead of "dist" I think, sorry for that)