### PR TITLE
if size is a string then concatenation occurs

### DIFF
--- a/src/js/extensions/page.js
+++ b/src/js/extensions/page.js
@@ -251,7 +251,7 @@ Page.prototype.getRows = function(data){
 	if(this.mode == "local"){
 		output = [];
 		start = this.size * (this.page - 1);
-		end = start + this.size;
+		end = start + parseInt(this.size);
 
 		this._setPageButtons();
 


### PR DESCRIPTION
If the user passes in a String as the paginationSize then the value of Start is calculated correctly but the value of End is incorrect as string concatenation occurs.