### PR TITLE
Fix duplicate `dataLoaded` callback called by ajax

### DIFF
--- a/src/js/extensions/ajax.js
+++ b/src/js/extensions/ajax.js
@@ -115,8 +115,6 @@ Ajax.prototype.sendRequest = function(callback){
 					data = self.table.options.ajaxResponse(self.url, self.params, data);
 				}
 
-				self.table.options.dataLoaded(data);
-
 				callback(data);
 
 				self.hideLoader();


### PR DESCRIPTION
Duplicate `dataLoaded` callback called by ajax.

```javascript
{
  columns: [{
    title: "number",
    field: "number",
  }],
  ajaxURL: "/echo/json", // echo back POST data
  ajaxParams: {
    json: JSON.stringify([{number:1},{number:2},{number:3}])
  },
  ajaxConfig: "POST",
  dataLoaded: function(data) {
    console.log("dataLoaded", data); // callback called 2 time...
  }
})
```

When settings has `pagination: "remote"`, callback argument value get wrong.
* 1st dataLoaded callback
argument is ajaxResponse Object.
* 2nd dataLoaded callback
argument is row_manager called row object.

There is reproduction code on jsfiddle https://jsfiddle.net/kacchi/yyd6w532/
