### PR TITLE
Adding optional argument whether to refresh grid after filter change

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -732,10 +732,12 @@
 	 		},
 
 	 		//add filter to array
-	 		addFilter:function(field, type, value){
+	 		addFilter:function(field, type, value, triggerRefresh = true){
 	 			if(this.extExists("filter", true)){
 	 				this.extensions.filter.addFilter(field, type, value);
-	 				this.rowManager.filterRefresh();
+					if(triggerRefresh) {
+					 	this.rowManager.filterRefresh();
+					}
 	 			}
 	 		},
 
@@ -761,10 +763,12 @@
 
 
 	 		//remove filter from array
-	 		removeFilter:function(field, type, value){
+	 		removeFilter:function(field, type, value, triggerRefresh = true){
 	 			if(this.extExists("filter", true)){
-	 				this.extensions.filter.removeFilter(field, type, value);
-	 				this.rowManager.filterRefresh();
+					 this.extensions.filter.removeFilter(field, type, value);
+					 if(triggerRefresh) {
+					 	this.rowManager.filterRefresh();
+					 }
 	 			}
 	 		},
 


### PR DESCRIPTION
Use case:
With single button click you need both: to remove filter and add new filter. Since it is needed to call both `addFilter` and `removeFilter` - 2 HTTP requests will be made. 
This pull request would improve this situation by adding boolean property, whether to refresh data after filter change. Usage:
`
$("#example-table").tabulator("removeFilter", "age", ">", 15, false); /* <- false indicates not to refresh the data */
$("#example-table").tabulator("addFilter", "age", ">", 10);
`
Ajax request would only be done after the `addFilter`.
Parameter to refresh data by default is true (represent the way it is right now), so it is backwards compatible.