### PR TITLE
Add select formatter and editor

### DIFF
--- a/src/js/extensions/edit.js
+++ b/src/js/extensions/edit.js
@@ -322,6 +322,40 @@ Edit.prototype.editors = {
 
 		return input;
 	},
+	
+	//select
+	select: function (cell, onRendered, success, cancel, editorParams) {
+		//create and style select
+		var select = $("<select/>");
+
+		$.each(editorParams, function (value, option) {
+			select.append($("<option>").attr('value', value).text(option));
+		});
+
+		select.val(cell.getValue()).css({
+			"padding": "0px",
+			"width": "100%",
+			"height": "100%",
+			"box-sizing": "border-box"
+		});
+
+		onRendered(function () {
+			select.focus().click();
+		});
+
+		//submit new value on blur
+		select.on("change blur", function (e) {
+			success(select.val());
+		});
+
+		//submit new value on enter
+		select.on("keydown", function (e) {
+			if (e.keyCode === 13) {
+				success(select.val());
+			}
+		});
+		return select;
+	},
 
 	//start rating
 	star:function(cell, onRendered, success, cancel, editorParams){

--- a/src/js/extensions/format.js
+++ b/src/js/extensions/format.js
@@ -186,6 +186,15 @@ Format.prototype.formatters = {
 		}
 	},
 
+	//select
+	select: function (cell, formatterParams) {
+		if (!formatterParams.hasOwnProperty(cell.getValue())) {
+			console.warn('Missing display value for '+ cell.getValue());
+			return cell.getValue();
+		}
+		return formatterParams[cell.getValue()];
+	},
+
 	//star rating
 	star:function(cell, formatterParams){
 		var value = cell.getValue(),


### PR DESCRIPTION
Add a html `<select>` with `<option>`s 

example usage:
```
      "formatter": "select",
      "formatterParams": {
        "value1": "displayText",
        "value2": "displayText2"
      },
      "editor": "select",
      "editorParams": {
        "value1": "displayText",
        "value2": "displayText2"
      },
```

Definitely open to any feedback and suggestions you may have