### PR TITLE
Added Column controls to headers and more

### DIFF
--- a/src/js/column.js
+++ b/src/js/column.js
@@ -337,18 +337,54 @@ Column.prototype._buildHeader = function(){
 	}
 };
 
+//3.5 AA Checks whether the required extension exists before attempting to add an option
+Column.prototype._dropdownEnabledCheck = function(table, column, option,itemClass, itemText, itemIcon) {
+	
+	if(table.extExists("column_drop_down") && column.definition.headerControls){
+		table.extensions.column_drop_down.addMenuItem(column, option, itemClass, itemText, itemIcon);
+	}
+}
+
 //build header element for header
 Column.prototype._buildColumnHeader = function(){
 	var self = this,
 	def = self.definition,
 	table = self.table,
 	sortable;
-
+	
+	//3.5 AA set the column dropdown
+	if(table.extExists("column_drop_down") && typeof def.headerControls != "undefined"){
+		table.extensions.column_drop_down.initializeColumn(self, self.contentElement);
+	}		
+	
 	//set column sorter
 	if(table.extExists("sort")){
 		table.extensions.sort.initializeColumn(self, self.contentElement);
+		
+		if(typeof def.sortControl != "undefined") // 3.5 AA Check if the column sort control should show
+		{	
+			self._dropdownEnabledCheck(self.table, self , "sort", "tabulator-sortable" , "Sort", "");
+		}
 	}
-
+		
+	//3.5 AA Check if the column grouping control should show
+	if(table.extExists("groupRows") && typeof def.groupControl != "undefined")
+	{
+		self._dropdownEnabledCheck(self.table, self , "group", "tabulator-group" , "Group/Un-Group", "");
+	}
+	
+	//3.5 AA Check if the column freezing control should show
+	if(table.extExists("frozenColumns") && typeof def.freezeControl != "undefined")
+	{
+		self._dropdownEnabledCheck(self.table, self , "freezeColumn", "tabulator-freeze" , "Freeze/Un-Freeze", "");
+	}
+	
+	//3.5 AA Check if the column visibility control should show
+	if(typeof def.visibilityControl != "undefined")
+	{
+		self._dropdownEnabledCheck(self.table, self , "hideColumn", "tabulator-hide" , "Hide/Show", "");
+	}
+	
 	//set column formatter
 	if(table.extExists("format")){
 		table.extensions.format.initializeColumn(self);
@@ -694,9 +730,7 @@ Column.prototype.show = function(){
 	if(!this.visible){
 		this.visible = true;
 
-		this.element.css({
-			"display":"",
-		});
+		this.element.show();
 		this.table.columnManager._verticalAlignHeaders();
 
 		if(this.parent.isGroup){
@@ -720,9 +754,7 @@ Column.prototype.hide = function(){
 	if(this.visible){
 		this.visible = false;
 
-		this.element.css({
-			"display":"none",
-		});
+		this.element.hide();
 		this.table.columnManager._verticalAlignHeaders();
 
 		if(this.parent.isGroup){

--- a/src/js/column_manager.js
+++ b/src/js/column_manager.js
@@ -265,9 +265,7 @@ ColumnManager.prototype.moveColumn = function(from, to, after){
 	this._moveColumnInArray(this.columns, from, to, after);
 	this._moveColumnInArray(this.columnsByIndex, from, to, after, true);
 
-	if(this.table.options.columnMoved){
-		this.table.options.columnMoved(from.getComponent(), this.table.columnManager.getComponents());
-	}
+	this.table.options.columnMoved(from.getComponent());
 
 	if(this.table.options.persistentLayout && this.table.extExists("persistentLayout", true)){
 		this.table.extensions.persistentLayout.save();

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -127,7 +127,7 @@
 	 			cellEditCancelled:function(){},
 
 	 			//column callbacks
-	 			columnMoved:false,
+	 			columnMoved:function(){},
 	 			columnResized:function(){},
 	 			columnTitleChanged:function(){},
 	 			columnVisibilityChanged:function(){},
@@ -192,8 +192,6 @@
 	 			var self = this,
 	 			element = this.element;
 
-	 			self._clearObjectPointers();
-
 	 			self._mapDepricatedFunctionality();
 
 	 			self.bindExtensions();
@@ -221,13 +219,6 @@
 
 	 				// },20)
 	 			}
-	 		},
-
-	 		//clear pointers to objects in default config object
-
-	 		_clearObjectPointers: function(){
-	 			this.options.columns = this.options.columns.splice(0);
-	 			this.options.data = this.options.data.splice(0);
 	 		},
 
 
@@ -302,7 +293,7 @@
 
 	 			if(options.groupBy && this.extExists("groupRows", true)){
 	 				ext.groupRows.initialize();
-	 			}
+				}
 
 	 			if(this.extExists("ajax")){
 	 				ext.ajax.initialize();
@@ -362,13 +353,13 @@
 	 			var ua = navigator.userAgent;
 
 	 			if(ua.indexOf("Trident") > -1){
-	 				this.browser = "ie";
+	 				this.brower = "ie";
 	 				this.browserSlow = true;
 	 			}else if(ua.indexOf("Edge") > -1){
-	 				this.browser = "edge";
+	 				this.brower = "edge";
 	 				this.browserSlow = true;
 	 			}else{
-	 				this.browser = "other";
+	 				this.brower = "other";
 	 				this.browserSlow = false;
 	 			}
 	 		},

--- a/src/js/extensions/column_drop_down.js
+++ b/src/js/extensions/column_drop_down.js
@@ -1,0 +1,183 @@
+var ColumnDropdown = function(table){
+ 	this.table = table; //hold Tabulator object
+ 	//something to do with other extensions
+ };
+ 
+//How do you get Images
+//text source?
+ 
+//initialize column dropdown list with extensions
+ColumnDropdown.prototype.initializeColumn = function(column, content){
+	var self = this;
+
+	if(column.definition.ColumnDropdown !== false)
+	{
+		column.element.css({ "overflow": "visible"});
+		
+		content.append($("<select name='testlist' class='tabulator-column-dropdown-menu' style='width:22px; height:20px; position:absolute; overflow:visible; display: inline-block; top:4px; right:4px;'></select>"));
+		
+		//content.append($("<select name='testlist' class='tabulator-column-dropdown-menu'></select>"));		
+				
+		var MenuExpanded = false;
+		
+		$(".tabulator-column-dropdown-options").click(
+              function( event ) {
+				event.stopPropagation();
+                
+				if(MenuExpanded === true)
+				{
+					$(this).find('.tabulator-column-dropdown-menu').slideUp();
+					MenuExpanded = false;
+				}
+				else
+				{
+					$(this).children().slideDown();
+					MenuExpanded = true;
+				}
+             }
+        );
+		
+		$(".tabulator-column-dropdown-menu").val(-1); // If an option is already selected it won't trigger an onclick event
+		$(".tabulator-column-dropdown-menu").click(
+			function (event){
+				var test = this;
+				this.selectedIndex = -1; // the option clicked should not be selected 
+				event.stopPropagation();			
+			}
+		);
+		
+		$(".column-dropdown-option").mouseenter( // replace this with on focus in CSS
+              function () {
+                  $(this).css({ "background":"Green"});
+              }
+        );
+	}
+};
+
+
+ColumnDropdown.prototype.addMenuItem = function(column, option, itemClass, itemText, itemIcon){ //need an additional parameter that tells us what option this extension relates to 
+	var self = this,
+	currentDataGrouped = false;
+			
+			
+	var newMenuItem = "<option class='column-dropdown-option "+ itemClass +" ' style='position:relative; width:100%; height:25px; margin-left:-100px' ><div class='column-option-name' >" +itemText+ "</div><div class='column-dropdown-option-icon'></div></option>";	
+	
+	column.element.find(".tabulator-column-dropdown-menu").append(newMenuItem);
+	
+	if(option == "sort")
+	{
+		column.element.find("." + itemClass).on("click", function(e){ 
+		
+			var dir = column.extensions.sort.dir;
+			
+			dir = dir == "asc" ? "desc" : "asc";
+			
+			self.table.extensions.sort.setSort( column.definition.field , dir );
+			self.table.rowManager.sorterRefresh();
+		
+		});
+	}
+	else if(option == "group")
+	{
+		column.element.find("." + itemClass).on("click", function(e){ 	
+		
+		
+			if(!currentDataGrouped)
+			{	
+				self.table.extensions.groupRows.initialize(column.field);
+				self.table.rowManager.setDisplayRows(self.table.extensions.groupRows.getRows(self.table.rowManager.activeRows, true));
+				self.table.rowManager.renderTable();
+				currentDataGrouped = true;
+			}
+			else
+			{
+				self.table.rowManager.setDisplayRows(self.table.extensions.groupRows.getRows(self.table.rowManager.activeRows, true)); 
+				self.table.rowManager.refreshActiveData();
+				currentDataGrouped = false;
+			}
+						
+		});		
+	}
+	else if(option == "freezeColumn")
+	{
+		column.element.find("." + itemClass).on("click", function(e){ 
+		
+			//find the column set it's frozen property and re-render the table much better than below
+		
+			if(!column.definition.frozen)
+			{
+				var positionAfter = false;
+				var lastFrozenColumn = self.table.columnManager.columns[0];
+				
+				//go through all columns if none are frozen then position at the start if one is frozen then postion after
+				self.table.columnManager.columns.forEach(function (col, index){ 
+					if(typeof col.definition.frozen !== "undefined" && col.definition.frozen)
+					{
+						lastFrozenColumn = col; 
+						positionAfter = true;						
+					}					
+				});
+				
+				column.definition.frozen = true;
+				
+				self.table.columnManager.moveColumn(column, lastFrozenColumn, positionAfter);
+				
+				self.table.rowManager.redraw(true); 
+				self.table.columnManager.redraw(true); 
+				self.table.extensions.frozenColumns.reset(); 
+				
+				self.table.columnManager.columns.forEach(function (col){ // re-intialise each column as others may also be frozen
+					if(typeof col.definition.frozen !== "undefined" && col.definition.frozen)
+					{
+						self.table.extensions.frozenColumns.initializeColumn(col); 
+					}					
+				});
+				
+			}
+			else
+			{
+				column.definition.frozen = false;
+				
+				delete column.extensions.frozen; // if not deleted will cause frozen styles to be applied after removal
+				
+				column.element.removeClass("tabulator-frozen");
+				column.element.removeClass("tabulator-frozen-left");
+				column.element.removeClass("tabulator-frozen-right");
+				column.element.css({"position":"relative"});
+				column.element.css({"display":"inline-block"});
+				column.element.css({"left":""});
+			
+				column.cells.forEach(function(cell){
+					cell.element.removeClass("tabulator-frozen");
+					cell.element.css({"position":"relative"});
+					cell.element.removeClass("tabulator-frozen-left");
+					cell.element.removeClass("tabulator-frozen-right");
+				});
+				
+				self.table.extensions.frozenColumns.leftColumns.splice(self.table.extensions.frozenColumns.leftColumns.indexOf(column), 1);  
+				
+			}
+		
+			self.table.rowManager.redraw(true);
+			self.table.columnManager.redraw(true);
+						
+		});				
+	}
+	else if(option = "hideColumn")
+	{
+		column.element.find("." + itemClass).on("click", function(e){ 
+		
+			if(column.visible){
+				column.hide();
+			}
+			else
+			{
+				column.show();
+			}			
+			
+		});
+	}
+	
+}
+
+Tabulator.registerExtension("column_drop_down", ColumnDropdown);

--- a/src/js/extensions/edit.js
+++ b/src/js/extensions/edit.js
@@ -280,10 +280,8 @@ Edit.prototype.editors = {
 		.val(cell.getValue());
 
 		onRendered(function(){
+			input.focus();
 			input.css("height","100%");
-			setTimeout(function(){
-				input.focus();
-			}, 10);
 		});
 
 		//submit new value on blur
@@ -321,40 +319,6 @@ Edit.prototype.editors = {
 		});
 
 		return input;
-	},
-	
-	//select
-	select: function (cell, onRendered, success, cancel, editorParams) {
-		//create and style select
-		var select = $("<select/>");
-
-		$.each(editorParams, function (value, option) {
-			select.append($("<option>").attr('value', value).text(option));
-		});
-
-		select.val(cell.getValue()).css({
-			"padding": "0px",
-			"width": "100%",
-			"height": "100%",
-			"box-sizing": "border-box"
-		});
-
-		onRendered(function () {
-			select.focus().click();
-		});
-
-		//submit new value on blur
-		select.on("change blur", function (e) {
-			success(select.val());
-		});
-
-		//submit new value on enter
-		select.on("keydown", function (e) {
-			if (e.keyCode === 13) {
-				success(select.val());
-			}
-		});
-		return select;
 	},
 
 	//start rating

--- a/src/js/extensions/format.js
+++ b/src/js/extensions/format.js
@@ -186,15 +186,6 @@ Format.prototype.formatters = {
 		}
 	},
 
-	//select
-	select: function (cell, formatterParams) {
-		if (!formatterParams.hasOwnProperty(cell.getValue())) {
-			console.warn('Missing display value for '+ cell.getValue());
-			return cell.getValue();
-		}
-		return formatterParams[cell.getValue()];
-	},
-
 	//star rating
 	star:function(cell, formatterParams){
 		var value = cell.getValue(),

--- a/src/js/extensions/frozen_columns.js
+++ b/src/js/extensions/frozen_columns.js
@@ -147,6 +147,7 @@ FrozenColumns.prototype.layoutElement = function(element, column){
 	}
 };
 
+
 FrozenColumns.prototype._calcSpace = function(columns, index){
 	var width = 0;
 

--- a/src/js/extensions/group_rows.js
+++ b/src/js/extensions/group_rows.js
@@ -1,5 +1,3 @@
-
-
 //public group object
 var GroupComponent = function (group){
 	this.group = group;
@@ -238,7 +236,7 @@ Group.prototype.getHeadersAndRows = function(){
 			}
 		}
 	}else{
-		if(!this.groupList.length && this.groupManager.table.options.groupClosedShowCalcs){
+		if(this.groupManager.table.options.groupClosedShowCalcs){
 			if(this.groupManager.table.extExists("columnCalcs")){
 				if(this.groupManager.table.extensions.columnCalcs.hasTopCalcs()){
 					this.calcs.top = this.groupManager.table.extensions.columnCalcs.generateTopRow(this.rows)
@@ -447,12 +445,17 @@ var GroupRows = function(table){
 
 
 //initialize group configuration
-GroupRows.prototype.initialize = function(){
+GroupRows.prototype.initialize = function(field){
 	var self = this,
 	groupBy = self.table.options.groupBy,
 	startOpen = self.table.options.groupStartOpen,
 	groupHeader = self.table.options.groupHeader;
 
+	if(field !== undefined) //3.4 AA for cases when the column to allow grouping for is to be defined as an argument and not as an option only
+	{
+		groupBy = field;
+	}
+	
 	self.headerGenerator = [function(){return "";}];
 	this.startOpen = [function(){return false;}]; //starting state of group
 
@@ -536,6 +539,7 @@ GroupRows.prototype.initialize = function(){
 	this.initialized = true;
 
 };
+
 
 //return appropriate rows with group headers
 GroupRows.prototype.getRows = function(rows){

--- a/src/js/extensions/html_table_import.js
+++ b/src/js/extensions/html_table_import.js
@@ -1,6 +1,5 @@
 var HtmlTableImport = function(table){
 	this.table = table; //hold Tabulator object
-	this.hasIndex = false;
 };
 
 HtmlTableImport.prototype.parseTable = function(){
@@ -9,10 +8,9 @@ HtmlTableImport.prototype.parseTable = function(){
 	options = self.table.options,
 	columns = options.columns,
 	headers = $("th", element),
+	hasIndex = false,
 	rows = $("tbody tr", element),
 	data = [];
-
-	self.hasIndex = false;
 
 	self.table.options.htmlImporting();
 
@@ -31,7 +29,7 @@ HtmlTableImport.prototype.parseTable = function(){
 		var item = {};
 
 		//create index if the dont exist in table
-		if(!self.hasIndex){
+		if(!hasIndex){
 			item[options.index] = rowIndex;
 		}
 
@@ -166,7 +164,7 @@ HtmlTableImport.prototype._extractHeaders = function(element){
 		$("td:eq(" + index + ")", rows).data("field", col.field);
 
 		if(col.field == self.table.options.index){
-			self.hasIndex = true;
+			hasIndex = true;
 		}
 
 		if(!exists){

--- a/src/js/extensions_enabled.js
+++ b/src/js/extensions_enabled.js
@@ -20,3 +20,4 @@
 /*=include extensions/select_row.js */
 /*=include extensions/sort.js */
 /*=include extensions/validate.js */
+/*=include extensions/column_drop_down.js */

--- a/src/js/row.js
+++ b/src/js/row.js
@@ -47,15 +47,15 @@ RowComponent.prototype.normalizeHeight = function(){
 };
 
 RowComponent.prototype.select = function(){
-	this.row.table.extensions.selectRow.selectRows(this.row);
+	this.row.selectRows(this.row);
 };
 
 RowComponent.prototype.deselect = function(){
-	this.row.table.extensions.selectRow.deselectRows(this.row);
+	this.row.deselectRows(this.row);
 };
 
 RowComponent.prototype.toggleSelect = function(){
-	this.row.table.extensions.selectRow.toggleRow(this.row);
+	this.row.toggleRow(this.row);
 };
 
 RowComponent.prototype._getSelf = function(){

--- a/src/js/row_manager.js
+++ b/src/js/row_manager.js
@@ -458,7 +458,7 @@ RowManager.prototype.getHtml = function(active){
 			var def = column.getDefinition();
 
 			if(column.getVisibility()){
-				header += `<th>${(def.title || "")}</th>`;
+				header += `<th>${def.title}</th>`;
 			}
 		})
 
@@ -559,7 +559,7 @@ RowManager.prototype.filterRefresh = function(){
 		this.refreshActiveData();
 	}
 
-	this.scrollHorizontal(left);
+	this.element.scrollLeft(left);
 };
 
 //choose the path to refresh data after a sorter update
@@ -580,11 +580,6 @@ RowManager.prototype.sorterRefresh = function(){
 		this.refreshActiveData();
 	}
 
-	this.scrollHorizontal(left);
-};
-
-RowManager.prototype.scrollHorizontal = function(left){
-	this.scrollLeft = left;
 	this.element.scrollLeft(left);
 };
 


### PR DESCRIPTION
Each column can now have a Sort, Freeze, Group, Hide controls available through a dropdown menu on the header, this overcomes the limitations of having to set such options before rendering the grid or do so after rendering but externally.

Modifications were made to how freezing works, now it will order columns then freeze, allowing multiple columns to freeze even if they are not next to each other.

You can add the below to the column definition to make use of new features:
headerControls: true, sortControl: true, groupControl: true, freezeControl: true, visibilityControl: true, headerFilter: true, headerSort: false

You can now also apply multiple header filters by typing in values seperated by semicolons.

There might be more features which I forgot about.

Do excuse any messiness I am still new to front end development, I am aware of where improvements can be made and will do so when I can.

Thanks for creating this awesome grid!