### PR TITLE
Make validators optional by default

### DIFF
--- a/src/js/extensions/validate.js
+++ b/src/js/extensions/validate.js
@@ -87,76 +87,102 @@ Validate.prototype.validate = function(validators, cell, value){
 	return valid.length ? valid : true;
 };
 
-Validate.isEmptyOrValidate = function(callback) {
-	return function(cell, value, parameters){
-		// If it isn't empty then validate
-		return typeof value !== "undefined" || value === null || value === ""
-			|| callback(cell, value, parameters);
-	};
-};
 Validate.prototype.validators = {
 
 	//is integer
-	integer: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	integer: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		value = Number(value);
 		return typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
-	}),
+	},
 
 	//is float
-	float: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	float: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		value = Number(value);
 		return typeof value === 'number' && isFinite(value) && value % 1 !== 0;;
-	}),
+	},
 
 	//must be a number
-	numeric: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	numeric: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		return !isNaN(value);
-	}),
+	},
 
 	//must be a string
-	string: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	string: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		return isNaN(value);
-	}),
+	},
 
 
 	//maximum value
-	max: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	max: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		return parseFloat(value) <= parameters;
-	}),
+	},
 
 	//minimum value
-	min: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	min: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		return parseFloat(value) >= parameters;
-	}),
+	},
 
 	//minimum string length
-	minLength: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	minLength: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		return String(value).length >= parameters;
-	}),
+	},
 
 	//maximum string length
-	maxLength: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	maxLength: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		return String(value).length <= parameters;
-	}),
+	},
 
 	//in provided value list
-	in: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	in: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		if(typeof parameters == "string"){
 			parameters = parameters.split("|");
 		}
 
 		return value === "" || parameters.indexOf(value) > -1;
-	}),
+	},
 
 	//must match provided regex
-	regex: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	regex: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		var reg = new RegExp(parameters);
 
 		return reg.test(value);
-	}),
+	},
 
 	//value must be unique in this column
-	unique: Validate.isEmptyOrValidate(function(cell, value, parameters){
+	unique: function(cell, value, parameters){
+		if(value === "" || value === null || typeof value === "undefined"){
+			return true;
+		}
 		var unique = true;
 
 		var cellData = cell.getData();
@@ -172,7 +198,7 @@ Validate.prototype.validators = {
 		});
 
 		return unique;
-	}),
+	},
 
 	//must have a value
 	required:function(cell, value, parameters){

--- a/src/js/extensions/validate.js
+++ b/src/js/extensions/validate.js
@@ -115,22 +115,22 @@ Validate.prototype.validators = {
 
 	//maximum value
 	max:function(cell, value, parameters){
-		return parseFloat(value) <= parameters;
+		return !this.required(value) || parseFloat(value) <= parameters;
 	},
 
 	//minimum value
 	min:function(cell, value, parameters){
-		return parseFloat(value) >= parameters;
+		return !this.required(value) || parseFloat(value) >= parameters;
 	},
 
 	//minimum string length
 	minLength:function(cell, value, parameters){
-		return String(value).length >= parameters;
+		return !this.required(value) || String(value).length >= parameters;
 	},
 
 	//maximum string length
 	maxLength:function(cell, value, parameters){
-		return String(value).length <= parameters;
+		return !this.required(value) || String(value).length <= parameters;
 	},
 
 	//in provided value list

--- a/src/js/extensions/validate.js
+++ b/src/js/extensions/validate.js
@@ -87,70 +87,76 @@ Validate.prototype.validate = function(validators, cell, value){
 	return valid.length ? valid : true;
 };
 
-
+Validate.isEmptyOrValidate = function(callback) {
+	return function(cell, value, parameters){
+		// If it isn't empty then validate
+		return typeof value !== "undefined" || value === null || value === ""
+			|| callback(cell, value, parameters);
+	};
+};
 Validate.prototype.validators = {
 
 	//is integer
-	integer:function(cell, value, parameters){
+	integer: Validate.isEmptyOrValidate(function(cell, value, parameters){
 		value = Number(value);
 		return typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
-	},
+	}),
 
 	//is float
-	float:function(cell, value, parameters){
+	float: Validate.isEmptyOrValidate(function(cell, value, parameters){
 		value = Number(value);
 		return typeof value === 'number' && isFinite(value) && value % 1 !== 0;;
-	},
+	}),
 
 	//must be a number
-	numeric:function(cell, value, parameters){
+	numeric: Validate.isEmptyOrValidate(function(cell, value, parameters){
 		return !isNaN(value);
-	},
+	}),
 
 	//must be a string
-	string:function(cell, value, parameters){
+	string: Validate.isEmptyOrValidate(function(cell, value, parameters){
 		return isNaN(value);
-	},
+	}),
 
 
 	//maximum value
-	max:function(cell, value, parameters){
-		return !this.required(value) || parseFloat(value) <= parameters;
-	},
+	max: Validate.isEmptyOrValidate(function(cell, value, parameters){
+		return parseFloat(value) <= parameters;
+	}),
 
 	//minimum value
-	min:function(cell, value, parameters){
-		return !this.required(value) || parseFloat(value) >= parameters;
-	},
+	min: Validate.isEmptyOrValidate(function(cell, value, parameters){
+		return parseFloat(value) >= parameters;
+	}),
 
 	//minimum string length
-	minLength:function(cell, value, parameters){
-		return !this.required(value) || String(value).length >= parameters;
-	},
+	minLength: Validate.isEmptyOrValidate(function(cell, value, parameters){
+		return String(value).length >= parameters;
+	}),
 
 	//maximum string length
-	maxLength:function(cell, value, parameters){
-		return !this.required(value) || String(value).length <= parameters;
-	},
+	maxLength: Validate.isEmptyOrValidate(function(cell, value, parameters){
+		return String(value).length <= parameters;
+	}),
 
 	//in provided value list
-	in:function(cell, value, parameters){
+	in: Validate.isEmptyOrValidate(function(cell, value, parameters){
 		if(typeof parameters == "string"){
 			parameters = parameters.split("|");
 		}
 
 		return value === "" || parameters.indexOf(value) > -1;
-	},
+	}),
 
 	//must match provided regex
-	regex:function(cell, value, parameters){
+	regex: Validate.isEmptyOrValidate(function(cell, value, parameters){
 		var reg = new RegExp(parameters);
 
 		return reg.test(value);
-	},
+	}),
 
 	//value must be unique in this column
-	unique:function(cell, value, parameters){
+	unique: Validate.isEmptyOrValidate(function(cell, value, parameters){
 		var unique = true;
 
 		var cellData = cell.getData();
@@ -166,11 +172,11 @@ Validate.prototype.validators = {
 		});
 
 		return unique;
-	},
+	}),
 
 	//must have a value
 	required:function(cell, value, parameters){
-		return value !== "" & value !== null && typeof value != "undefined";
+		return value !== "" & value !== null && typeof value !== "undefined";
 	},
 };
 


### PR DESCRIPTION
This PR allows to have validators like min, max in optional columns.

E.g.

```js
$('#example-table').tabulator({
    columns:[
        {
            field: 'optional_1',
            title: 'My optional prop',
            editor: true,
            validator: ['integer', 'min:1', 'max:12']
        },
        {
            field: 'required_1',
            title: 'My required prop',
            editor: true,
            validator: ['required', 'integer', 'min:1', 'max:12']
        },
    ],
});
```

If `optional_1` is an empty string, null or undefined, it won't complain.