### PR TITLE
Include all columns of the definition

### DIFF
--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -15403,6 +15403,14 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
         }
       });
 
+      oldCols.forEach(function (column, to) {
+          var from = self._findColumn(newCols, column);
+
+          if (!from) {
+              output.push(column);
+          }
+      });
+
       return output;
     };
 

--- a/src/js/extensions/persistence.js
+++ b/src/js/extensions/persistence.js
@@ -89,6 +89,16 @@ Persistence.prototype.mergeDefinition = function(oldCols, newCols){
 		}
 
 	});
+	oldCols.forEach(function (column, i) {
+		var from = self._findColumn(newCols, column);
+		if (!from) {
+			if(output.length>i){
+				output.splice(i, 0, column);
+			}else{	
+				output.push(column);
+			}
+		}
+	});
 
 	return output;
 };


### PR DESCRIPTION
If the definition columns are merged with the persistentLayout columns, we need to see newly added columns. They are simply added to the right.