### PR TITLE
Make row's getData method returns a new object

### DIFF
--- a/src/js/row.js
+++ b/src/js/row.js
@@ -426,7 +426,7 @@ Row.prototype.getData = function(transform){
 			return self.table.extensions.accessor.transformRow(self.data, transform);
 		}
 	}else{
-		return this.data;
+		return Object.assign({}, this.data);
 	}
 
 };


### PR DESCRIPTION
This PR fixs the problem of returning the reference of the row's internal data object.

With this, the user code doesn't affect the row's data and vice versa.