### PR TITLE
Fix for Regex validator with ':' #1223

### DIFF
--- a/src/js/extensions/validate.js
+++ b/src/js/extensions/validate.js
@@ -35,9 +35,9 @@ Validate.prototype._extractValidator = function(value){
 
 	switch(typeof value){
 		case "string":
-		let parts = value.split(":");
+		let parts = value.split(":",1);
 		let type = parts.shift();
-		let params = parts.join();
+		let params = parts[0];
 
 		return this._buildValidator(type, params);
 		break;


### PR DESCRIPTION
Fix for #1223 
It seems that multiple validators has to be passed as array, so if the input is string, it contains only one validator.
split(':', 1) only break the string into two parts.