### PR TITLE
Finding rows and columns by jQuery doesn't work

### DIFF
--- a/src/js/column_manager.js
+++ b/src/js/column_manager.js
@@ -162,7 +162,7 @@ ColumnManager.prototype.findColumn = function(subject){
 		}else if(subject instanceof jQuery){
 			//subject is a jquery element of the column header
 			let match = self.columns.find(function(column){
-				return column.element === subject;
+				return column.element.is(subject);
 			});
 
 			return match || false;

--- a/src/js/row_manager.js
+++ b/src/js/row_manager.js
@@ -138,7 +138,7 @@ RowManager.prototype.findRow = function(subject){
 		}else if(subject instanceof jQuery){
 			//subject is a jquery element of the row
 			let match = self.rows.find(function(row){
-				return row.element === subject;
+				return row.element.is(subject);
 			});
 
 			return match || false;


### PR DESCRIPTION
Everytime you call `jQuery` a new object is created.

https://stackoverflow.com/a/6985990
> Using the `$()` function will always create a new object, so no matter what, your equality check there will always fail.

The correct way is to use the [`.is()`](http://api.jquery.com/is/) jQuery method.