### PR TITLE
Fix textarea editor: renders null values

### DIFF
--- a/src/js/extensions/edit.js
+++ b/src/js/extensions/edit.js
@@ -296,7 +296,7 @@ Edit.prototype.editors = {
 	textarea:function(cell, onRendered, success, cancel, editorParams){
 		var self = this,
 		cellValue = cell.getValue(),
-		value = String(cellValue == null ? "" : cellValue),
+		value = String(typeof cellValue == "undefined" || cellValue === null ? "" : cellValue),
 		count = (value.match(/(?:\r\n|\r|\n)/g) || []).length + 1,
 		input = $("<textarea></textarea>"),
 		scrollHeight = 0;

--- a/src/js/extensions/edit.js
+++ b/src/js/extensions/edit.js
@@ -296,7 +296,7 @@ Edit.prototype.editors = {
 	textarea:function(cell, onRendered, success, cancel, editorParams){
 		var self = this,
 		cellValue = cell.getValue(),
-		value = String(typeof cellValue == "null" || typeof cellValue == "undefined" ? "" : cellValue),
+		value = String(cellValue == null ? "" : cellValue),
 		count = (value.match(/(?:\r\n|\r|\n)/g) || []).length + 1,
 		input = $("<textarea></textarea>"),
 		scrollHeight = 0;


### PR DESCRIPTION
### Bug

It renders null values into textarea cells.

How to replicate it: https://codepen.io/lgraziani/pen/yqbQgY?editors=0010

Click on the cell to see how it renders the null value.

This PR fix the issue: https://codepen.io/lgraziani/pen/JBNerO?editors=0010

### Why `value == null`?

http://adripofjavascript.com/blog/drips/equals-equals-null-in-javascript.html

> Despite the fact that null is a falsy value (i.e. it evaluates to false if coerced to a boolean), it isn't considered loosely equal to any of the other falsy values in JavaScript. In fact, the only values that null is loosely equal to are undefined and itself.
>
> Because of this interesting property, it has become somewhat conventional to use == null as a more concise way of checking whether a given value is "nothing" (null/undefined) or "something" (anything else).

Thank you for your work!