### PR TITLE
Get the text for the title of pagination buttons from locale

### DIFF
--- a/src/js/modules/localize.js
+++ b/src/js/modules/localize.js
@@ -185,6 +185,7 @@ Localize.prototype.langs = {
 			"prev_title":"Prev Page",
 			"next":"Next",
 			"next_title":"Next Page",
+			"page_button_title":"Show Page ${page}",
 		},
 		"headerFilters":{
 			"default":"filter column...",

--- a/src/js/modules/page.js
+++ b/src/js/modules/page.js
@@ -254,8 +254,10 @@ Page.prototype._generatePageButton = function(page){
 
 	button.setAttribute("type", "button");
 	button.setAttribute("role", "button");
-	button.setAttribute("aria-label", "Show Page " + page);
-	button.setAttribute("title", "Show Page " + page);
+	var title = self.table.modules.localize.getText( "pagination", "page_button_title" );
+	title = title.split( "${page}" ).join( page );
+	button.setAttribute("aria-label", title );
+	button.setAttribute("title", title ); 
 	button.setAttribute("data-page", page);
 	button.textContent = page;
 


### PR DESCRIPTION
The text for the title of pagination buttons (the ones with the numbers) is hardcoded, not localized. I added a localization entry for this:

`"page_button_title":"Show Page ${page}",`

As the text must include the page number, I used the ${page} sequence which is replaced with the actual value.
If you don't like this approach I'll be happy to implement it in another way, along with the binding mechanism that is now missing for these buttons.
Thanks a lot.