### PR TITLE
feature: add autocomp editor

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -535,6 +535,7 @@ Edit.prototype.editors = {
 		list.style.zIndex = 1;
 		list.style.width = "100%";
 		list.style.maxHeight = "135px";
+		list.style.marginTop = "4px";
 		list.style.overflowY = "auto";
 
 		var isArray = Array.isArray(editorParams);
@@ -576,7 +577,7 @@ Edit.prototype.editors = {
 		}
 
 		function onkey(e) {
-			if (e.keyCode >= 48 || e.keyCode <= 13) {
+			if (e.keyCode >= 48 || e.keyCode <= 13 || e.keyCode == 32) {
 				for (let i = 0; i < list.children.length; i += 1) {
 					const child = list.children[i];
 					if (child.innerText.toLowerCase().indexOf(e.target.value.toLowerCase()) >= 0) {

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -576,7 +576,7 @@ Edit.prototype.editors = {
 		}
 
 		function onkey(e) {
-			if (e.keyCode < 38 && e.keyCode > 42) {		// if not Arrow Keys
+			if (e.keyCode >= 48 || e.keyCode <= 13) {
 				for (let i = 0; i < list.children.length; i += 1) {
 					const child = list.children[i];
 					if (child.innerText.toLowerCase().indexOf(e.target.value.toLowerCase()) >= 0) {

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -528,11 +528,12 @@ Edit.prototype.editors = {
 			isArray = Array.isArray(editorParams.values);
 		}
 
-		function addListItems(element, label, value){
+		function addListItems(element, label, value, idx){
 			var item = document.createElement("li");
 			item.innerHTML = value;
 			item.style.padding = "5px";
 			item.dataset.value = value;
+			item.tabIndex = "" + idx;
 			item.onmousedown = function(e) {
 				success(e.target.dataset.value);
 			}
@@ -540,8 +541,10 @@ Edit.prototype.editors = {
 		}
 
 		if(!isArray && editorParams && typeof editorParams.values === "object"){
+			var idx = 0;
 			for(var key in editorParams.values){
-				addListItems(list, editorParams.values[key], key)
+				addListItems(list, editorParams.values[key], key, idx)
+				idx = idx + 1;
 			}
 		}
 
@@ -565,13 +568,43 @@ Edit.prototype.editors = {
 		}
 		input.onkeyup = onkey;
 		input.onkeypress = onkey;
+
+		var activeItem = list.firstChild;
+		list.onkeydown = function(e) {
+			switch (e.keyCode) {
+				case 13:
+					success(activeItem.dataset.value);
+					break;
+				case 27:
+					cancel();
+					break;
+				case 38: // if the UP key is pressed
+					e.preventDefault();
+					e.stopPropagation();
+					if (activeItem.previousSibling) {
+						activeItem = activeItem.previousSibling;
+						activeItem.focus();
+					}
+					break;
+				case 40: // if the DOWN key is pressed
+					e.preventDefault();
+					e.stopPropagation();
+					if (activeItem.nextSibling) {
+						activeItem = activeItem.nextSibling;
+						activeItem.focus();
+					}
+					break;
+			}
+		}
 		input.onkeydown = function(e) {
 			switch (e.keyCode) {
 				case 40: // if the DOWN key is pressed
+					e.preventDefault();
+					e.stopPropagation();
 					for (let i = 0; i < list.children.length; i += 1) {
 						const child = list.children[i];
 						if (child.style.display === "block") {
-							success(child.innerText);
+							child.focus();
 							break;
 						}
 					}
@@ -595,9 +628,9 @@ Edit.prototype.editors = {
 			}
 		}
 		//submit new value on blur
-		input.addEventListener("blur", function(e){
-			onChange();
-		});
+		// input.addEventListener("blur", function(e){
+		// 	onChange();
+		// });
 
 		// add to container
 		container.appendChild(input);


### PR DESCRIPTION
usage (as discussed in https://github.com/olifolkerd/tabulator/issues/1513)

```
column config:
{title:"Name", field:"name", editor:"autocomp", editorParams:{
    values:{
        "steve":"Steve Boberson",
        "bob":"Bob Jimmerson",
        "jim":"Jim Stevenson",
    }
}}
```

@olifolkerd this is just a basic autocomplete input, type a partial text & press "Down" key to select the first matched text. One enhancement can be navigating the matched items using arrow keys.

![image](https://user-images.githubusercontent.com/639189/47199358-06236100-d326-11e8-9c45-fa5bdba94291.png)
