### PR TITLE
Fix table bg color in Bootstrap theme

### DIFF
--- a/src/scss/bootstrap/tabulator_bootstrap4.scss
+++ b/src/scss/bootstrap/tabulator_bootstrap4.scss
@@ -331,7 +331,6 @@ $footerSeperatorColor:$table-border-color !default; //footer bottom seperator co
 		.tabulator-table{
 			position:relative;
 			display:inline-block;
-			background-color:$rowBackgroundColor;
 			white-space: nowrap;
 			overflow:visible;
 


### PR DESCRIPTION
While using the bootstrap theme I found that when trying to set a custom `$backgroundColor` variable for the table it was being overridden by something.

On investigating further I found @ line 331:
```
.tabulator-table{
   position:relative;
   display:inline-block;
   background-color:$rowBackgroundColor;
   white-space: nowrap;
   overflow:visible;
```

Here we can see that the `.tabulator-table` wrapper has its background-color being set to the `$rowBackgroundColor` variable... which then overrides  `.tabulator` background color being set on line 43 with the `$backgroundColor` variable.

Unless I'm mistaken, line 334 isn't needed, hence this change to remove it and allow the table background color to actually be set by the `$backgroundColor` variable.

Thanks!