### PR TITLE
Fix deselect "row" when do ".deleteRow()"

### DIFF
--- a/src/js/row.js
+++ b/src/js/row.js
@@ -554,7 +554,7 @@ Row.prototype.deleteActual = function(){
 
 	//deselect row if it is selected
 	if(this.table.modExists("selectRow")){
-		this.table.modules.selectRow._deselectRow(this.row, true);
+		this.table.modules.selectRow._deselectRow(this, true);
 	}
 
 	this.table.rowManager.deleteRow(this);


### PR DESCRIPTION
Looks like `this` is `row component` itself. Fixes deselecting when you are removing selected *row*.