### PR TITLE
clearHeaderFilter fix for checkboxes

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1349,6 +1349,13 @@ Tabulator.prototype.getGroups = function(values){
 	}
 };
 
+// get grouped table data in the same format as getData()
+Tabulator.prototype.getGroupedData = function(){
+	if (this.modExists("groupRows", true)){
+		return this.options.groupBy ? 
+				this.modules.groupRows.getGroupedData() : this.getData()
+	}
+}
 
 ///////////////// Column Calculation Functions ///////////////
 Tabulator.prototype.getCalcResults = function(){

--- a/src/js/modules/filter.js
+++ b/src/js/modules/filter.js
@@ -495,11 +495,18 @@ Filter.prototype.clearFilter = function(all){
 };
 
 //clear header filters
-Filter.prototype.clearHeaderFilter = function(){
+Filter.prototype.clearHeaderFilter = function () {
 	this.headerFilters = {};
 
-	this.headerFilterElements.forEach(function(element){
-		element.value = "";
+	this.headerFilterElements.forEach(function (element) {
+		if (!element.tagName.localeCompare("input", 'en', {sensitivity: 'base'}) && !element.type.localeCompare("checkbox", 'en', {sensitivity: 'base'})) {
+			if (element.checked) {
+				element.click();
+			}
+		}
+		else {
+			element.value = "";
+		}
 	});
 
 	this.changed = true;

--- a/src/js/modules/group_rows.js
+++ b/src/js/modules/group_rows.js
@@ -765,20 +765,22 @@ GroupRows.prototype.getGroups = function(){
 };
 
 GroupRows.prototype.pullGroupListData = function(groupList) {
-	var groupListData = [];
-	groupListData.subGroupRowCount = 0;
 	var self = this;
+	var groupListData = [];
 
 	groupList.forEach( function(group) {
 		var groupHeader = {};
+			groupHeader.level = 0;
+			groupHeader.rowCount = 0;
+			groupHeader.headerContent = "";
 		var childData = [];
 
 		if (group.hasSubGroups) {
 			childData = self.pullGroupListData(group.groupList);
 
 			groupHeader.level = group.level;
-			groupHeader.rowCount = childData.subGroupRowCount;
-			groupHeader.headerContent = group.generator(group.key, childData.subGroupRowCount, group.rows, group);
+			groupHeader.rowCount = childData.length - group.groupList.length; // data length minus number of sub-headers
+			groupHeader.headerContent = group.generator(group.key, groupHeader.rowCount, group.rows, group);
 
 			groupListData.push(groupHeader);
 			groupListData = groupListData.concat(childData);
@@ -791,12 +793,8 @@ GroupRows.prototype.pullGroupListData = function(groupList) {
 
 			groupListData.push(groupHeader);
 
-			if (group.parent) { 
-				groupListData.subGroupRowCount += groupHeader.rowCount;
-			}
-
 			group.getRows().forEach( function(row) {
-				groupListData.push(row.getData());
+				groupListData.push(row.getData("data"));
 			});
 		}
 	});

--- a/src/js/modules/group_rows.js
+++ b/src/js/modules/group_rows.js
@@ -764,6 +764,51 @@ GroupRows.prototype.getGroups = function(){
 	return groupComponents;
 };
 
+GroupRows.prototype.pullGroupListData = function(groupList) {
+	var groupListData = [];
+	groupListData.subGroupRowCount = 0;
+	var self = this;
+
+	groupList.forEach( function(group) {
+		var groupHeader = {};
+		var childData = [];
+
+		if (group.hasSubGroups) {
+			childData = self.pullGroupListData(group.groupList);
+
+			groupHeader.level = group.level;
+			groupHeader.rowCount = childData.subGroupRowCount;
+			groupHeader.headerContent = group.generator(group.key, childData.subGroupRowCount, group.rows, group);
+
+			groupListData.push(groupHeader);
+			groupListData = groupListData.concat(childData);
+		}
+
+		else {	
+			groupHeader.level = group.level;
+			groupHeader.headerContent = group.generator(group.key, group.rows.length, group.rows, group);
+			groupHeader.rowCount = group.getRows().length;
+
+			groupListData.push(groupHeader);
+
+			if (group.parent) { 
+				groupListData.subGroupRowCount += groupHeader.rowCount;
+			}
+
+			group.getRows().forEach( function(row) {
+				groupListData.push(row.getData());
+			});
+		}
+	});
+
+	return groupListData
+};
+
+GroupRows.prototype.getGroupedData = function(){
+
+	return this.pullGroupListData(this.groupList);
+};
+
 GroupRows.prototype.getRowGroup = function(row){
 	var match = false;
 


### PR DESCRIPTION
when clearing filters, even with `clearFilter(true)`, the filter would clear from the data but the checkbox in the header would stay checked. setting the checked value to `false` did not work either; it would de-register the input and force me to check, uncheck and recheck it just to use the filter again. `click()` handler works just fine.