### PR TITLE
fix cssClass can not have multi classes using space

### DIFF
--- a/src/js/cell.js
+++ b/src/js/cell.js
@@ -123,7 +123,10 @@ Cell.prototype._configureCell = function(){
 	}
 
 	if(self.column.definition.cssClass){
-		element.classList.add(self.column.definition.cssClass);
+		var classNames = self.column.definition.cssClass.split(" ")
+		classNames.forEach(function(className) {
+			element.classList.add(className)
+		});
 	}
 
 	//set event bindings

--- a/src/js/column.js
+++ b/src/js/column.js
@@ -494,7 +494,10 @@ Column.prototype._buildColumnHeader = function(){
 
 	//asign additional css classes to column header
 	if(def.cssClass){
-		self.element.classList.add(def.cssClass);
+		var classeNames = def.cssClass.split(" ");
+		classeNames.forEach(function(className) {
+			self.element.classList.add(className)
+		});
 	}
 
 	if(def.field){


### PR DESCRIPTION
Hi Oli,
As document said, cssClass value should be a string containing space separated class names, but in current there will be an error said 「Uncaught DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided ('aaa bbb') contains HTML space characters, which are not valid in tokens.」.
It looks like you can not put the string with space to the list directly, it should be separated before add to classList.
I try to fix this problem and please check if it is appropriate, thanks!