### PR TITLE
1618: On selectRow/deselectRow, call rowSelectionChanged once

### DIFF
--- a/src/js/modules/select_row.js
+++ b/src/js/modules/select_row.js
@@ -139,7 +139,7 @@ SelectRow.prototype.selectRows = function(rows){
 	switch(typeof rows){
 		case "undefined":
 		self.table.rowManager.rows.forEach(function(row){
-			self._selectRow(row, false, true);
+			self._selectRow(row, true, true);
 		});
 
 		self._rowSelectionChanged();
@@ -148,7 +148,7 @@ SelectRow.prototype.selectRows = function(rows){
 		case "boolean":
 		if(rows === true){
 			self.table.rowManager.activeRows.forEach(function(row){
-				self._selectRow(row, false, true);
+				self._selectRow(row, true, true);
 			});
 
 			self._rowSelectionChanged();
@@ -219,14 +219,14 @@ SelectRow.prototype.deselectRows = function(rows){
 		rowCount = self.selectedRows.length;
 
 		for(let i = 0; i < rowCount; i++){
-			self._deselectRow(self.selectedRows[0], false);
+			self._deselectRow(self.selectedRows[0], true);
 		}
 
 		self._rowSelectionChanged();
 	}else{
 		if(Array.isArray(rows)){
 			rows.forEach(function(row){
-				self._deselectRow(row);
+				self._deselectRow(row, true);
 			});
 
 			self._rowSelectionChanged();


### PR DESCRIPTION
- Bug fix: Any calls to selectRow and deselectRow should call
rowSelectionChanged only once.
- This was fixed in SHA 010b37eaec for cases when an array is passed.
However, the problem also exists when passing true or no parameter,
which should select active rows or all rows.
- Also, calls to deselectRows had the same issue so this is
fixed as well.