### PR TITLE
Properly dispose of old header filter elements

### DIFF
--- a/src/js/modules/filter.js
+++ b/src/js/modules/filter.js
@@ -106,7 +106,18 @@ Filter.prototype.generateHeaderFilterElement = function(column, initialValue){
 	function cancel(){}
 
 	if(column.modules.filter.headerElement && column.modules.filter.headerElement.parentNode){
-		column.modules.filter.headerElement.parentNode.removeChild(column.modules.filter.headerElement);
+		var oldFilterElement = column.modules.filter.headerElement.parentNode;
+		var oldFilterElementIndex = self.headerFilterElements.indexOf(oldFilterElement);
+		if (oldFilterElementIndex >= 0) {
+			self.headerFilterElements.splice(oldFilterElementIndex, 1);
+		}
+
+		var oldColumnIndex = self.headerFilterColumns.indexOf(oldColumnIndex);
+		if (oldColumnIndex >= 0) {
+			self.headerFilterColumns.splice(oldColumnIndex, 1);
+		}
+
+		column.contentElement.removeChild(oldFilterElement);
 	}
 
 	if(field){


### PR DESCRIPTION
---
Old header filter elements are not removed from DOM
---

**Describe the bug**
Old filter elements are not removed from column content element. As a result, if you use setHeaderFilterValue or other methods that use generateHeaderFilterElement it creates this kind of DOM

![image](https://user-images.githubusercontent.com/3966291/50480287-4f092d00-09db-11e9-992f-9fc5e21436a9.png)

If header filters have some styling it becomes more apparent, since this styling applies to old filter elements as well.

**To Reproduce**
Steps to reproduce the behavior:
1. call setHeaderFilterValue method on the table with some new value
2. look up the filter element in DOM or add this CSS 
```
.tabulator-header-filter {
    background-color: red;
    padding: 5px;
}
```

**Expected behavior**
old filter elements to be removed from DOM

**Screenshots**
![image](https://user-images.githubusercontent.com/3966291/50480385-ec646100-09db-11e9-8399-1e38f5550a23.png)
