### PR TITLE
Allow persistence ID to be changed

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -991,7 +991,11 @@ Tabulator.prototype.copyToClipboard = function(selector, selectorParams, formatt
 /////////////// Column Functions  ///////////////
 
 Tabulator.prototype.setColumns = function(definition){
-	this.columnManager.setColumns(definition);
+  	if(this.options.persistentLayout && this.modExists("persistence", true)){
+    	definition = this.modules.persistence.load("columns", definition);
+  	}
+
+  	this.columnManager.setColumns(definition);
 };
 
 Tabulator.prototype.getColumns = function(structured){

--- a/src/js/modules/persistence.js
+++ b/src/js/modules/persistence.js
@@ -14,6 +14,10 @@ Persistence.prototype.initialize = function(mode, id){
 	this.id = "tabulator-" + (id || (this.table.element.getAttribute("id") || ""));
 };
 
+Persistence.prototype.setID = function(id) {
+	this.id = "tabulator-" + id;
+}
+
 //load saved definitions
 Persistence.prototype.load = function(type, current){
 

--- a/src/js/modules/resize_columns.js
+++ b/src/js/modules/resize_columns.js
@@ -44,6 +44,9 @@ ResizeColumns.prototype.initializeColumn = function(type, column, element){
 		handle.addEventListener("dblclick", function(e){
 			if(self._checkResizability(column)){
 				column.reinitializeWidth(true);
+				if(self.table.options.persistentLayout && self.table.modExists("persistence", true)){
+					self.table.modules.persistence.save("columns");
+				}
 			}
 		});
 


### PR DESCRIPTION
Allow a new persistence ID to be set, allowing different column layouts for the same table.

- New function in persistence module: setID
- Tabulator.setColumns now reloads persistent column
setup before setting columns.
- Also save persistent columns on header double-click resize.

My use case for this is that the columns in my table can change based on certain external events (new setup docs are loaded from a database).  When this happens, I reload the columns in my table using setColumns.  However, as the columns are now different from the previous persistent set that have been saved for this table, the layout gets reset to the default.  To overcome this, I change the ID when the number of columns change, saving a new table layout for each set of columns.

This is not possible with the master Tabulator code as the persistent ID is set on initialisation and the columns are only loaded once, at that point.

When the columns change I now call the following:

```
          if (table.modExists("persistence")) {
            table.modules.persistence.setID(tableId + newTabColumns.length);
          }  
          table.setColumns(newTabColumns);
```

I think that this may be a useful addition for others, hence the merge request.
