### PR TITLE
added return so that page load promises can be accessed above module scope

### DIFF
--- a/dist/js/tabulator_core.js
+++ b/dist/js/tabulator_core.js
@@ -6191,7 +6191,7 @@ Tabulator.prototype.previousPage = function () {
 	if (this.options.pagination && this.modExists("page")) {
 		return this.modules.page.previousPage();
 	} else {
-		return false;
+		return Promise.reject(new Error('Module does not exist'));
 	}
 };
 
@@ -6199,7 +6199,7 @@ Tabulator.prototype.nextPage = function () {
 	if (this.options.pagination && this.modExists("page")) {
 		return this.modules.page.nextPage();
 	} else {
-		return false;
+		return Promise.reject(new Error('Module does not exist'));
 	}
 };
 

--- a/dist/js/tabulator_core.js
+++ b/dist/js/tabulator_core.js
@@ -6189,7 +6189,7 @@ Tabulator.prototype.getPageSize = function () {
 
 Tabulator.prototype.previousPage = function () {
 	if (this.options.pagination && this.modExists("page")) {
-		this.modules.page.previousPage();
+		return this.modules.page.previousPage();
 	} else {
 		return false;
 	}
@@ -6197,7 +6197,7 @@ Tabulator.prototype.previousPage = function () {
 
 Tabulator.prototype.nextPage = function () {
 	if (this.options.pagination && this.modExists("page")) {
-		this.modules.page.nextPage();
+		return this.modules.page.nextPage();
 	} else {
 		return false;
 	}


### PR DESCRIPTION
When trying
var table = new Tabulator('#table', {//config});
table.nextPage().then(function(){
})

nextPage() returns undefined.
you have to use table.modules.page.nextPage() in order to return the promise.