### PR TITLE
Number sorter: parse numbers with multiple commas

### DIFF
--- a/src/js/modules/sort.js
+++ b/src/js/modules/sort.js
@@ -291,11 +291,11 @@ Sort.prototype.sorters = {
 	number:function(a, b, aRow, bRow, column, dir, params){
 		var alignEmptyValues = params.alignEmptyValues;
 		var decimal = params.decimalSeparator || ".";
-		var separator = params.thousandsSeparator || ",";
+		var thousand = params.thousandSeparator || ",";
 		var emptyAlign = 0;
 
-		a = parseFloat(String(a).split(separator).join("").split(decimal).join("."));
-		b = parseFloat(String(b).split(separator).join("").split(decimal).join("."));
+		a = parseFloat(String(a).split(thousand).join("").split(decimal).join("."));
+		b = parseFloat(String(b).split(thousand).join("").split(decimal).join("."));
 
 		//handle non numeric values
 		if(isNaN(a)){

--- a/src/js/modules/sort.js
+++ b/src/js/modules/sort.js
@@ -290,10 +290,12 @@ Sort.prototype.sorters = {
 	//sort numbers
 	number:function(a, b, aRow, bRow, column, dir, params){
 		var alignEmptyValues = params.alignEmptyValues;
+		var decimal = params.decimalSeparator || ".";
+		var separator = params.thousandsSeparator || ",";
 		var emptyAlign = 0;
 
-		a = parseFloat(String(a).replace(",",""));
-		b = parseFloat(String(b).replace(",",""));
+		a = parseFloat(String(a).split(separator).join("").split(decimal).join("."));
+		b = parseFloat(String(b).split(separator).join("").split(decimal).join("."));
 
 		//handle non numeric values
 		if(isNaN(a)){


### PR DESCRIPTION
Resolves #1724 So that numbers with more than one comma in them will be parsed correctly.

I also added 2 parameters `decimalSeparator` and `thousandSeparator` for the number format, but could not find the docs in this repo to update.