### PR TITLE
Parse select editor options and set current item when creating editor

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -650,8 +650,6 @@ Edit.prototype.editors = {
 
 			dataItems = dataList;
 			displayItems = displayList;
-
-			fillList();
 		}
 
 		function fillList(){
@@ -732,15 +730,20 @@ Edit.prototype.editors = {
 			cancel();
 		}
 
+		function parseFromEditorParamsOrColumnValues () {
+			if (editorParams.values === true) {
+				parseItems(getUniqueColumnValues(), initialValue);
+			}
+			else {
+				parseItems(editorParams.values || [], initialValue);
+			}
+		}
+
 		function showList(){
 			if(!listEl.parentNode){
 
-				if(editorParams.values === true){
-					parseItems(getUniqueColumnValues(), initialValue);
-				}else{
-					parseItems(editorParams.values || [], initialValue);
-				}
-
+				parseFromEditorParamsOrColumnValues();
+				fillList();
 
 				var offset = Tabulator.prototype.helpers.elOffset(cellEl);
 
@@ -750,6 +753,7 @@ Edit.prototype.editors = {
 				listEl.style.left = offset.left + "px";
 				document.body.appendChild(listEl);
 			}
+
 		}
 
 		function hideList(){
@@ -820,6 +824,8 @@ Edit.prototype.editors = {
 		//style list element
 		listEl = document.createElement("div");
 		listEl.classList.add("tabulator-edit-select-list");
+
+		parseFromEditorParamsOrColumnValues();
 
 		onRendered(function(){
 			input.style.height = "100%";


### PR DESCRIPTION
---
name: Select editor header filter input box not populated with initial value on creation.
---

**Describe the bug**
When using setHeaderFilterValue on a column with select editor tabulator doesn't calculate the displayItems and doesn't set the current item/initial value on the input text box.
This is different from select editor in cells, since editor is only visible when user clicks onto the cell, which causes it to calculate display options, create a dropdown and consequently set the value on the input text box.

**To Reproduce**
Steps to reproduce the behavior:
1. use setHeaderFilterValue on a column with select editor header filter.

Alternatively, I think this can be reproduced with persistent config.
