### PR TITLE
Pass through Date object to sheet_add_aoa so can be Date field in Excel

### DIFF
--- a/src/js/modules/download.js
+++ b/src/js/modules/download.js
@@ -779,7 +779,7 @@ Download.prototype.downloaders = {
 
 				fields.forEach(function(field){
 					var value = self.getFieldValue(field, row);
-					rowData.push(typeof value === "object" ? JSON.stringify(value) : value);
+					rowData.push(!(i instanceof Date) && typeof value === "object" ? JSON.stringify(value) : value);
 				});
 
 				return rowData;


### PR DESCRIPTION
XLSX.utils.sheet_add_aoa handles Date objects and formats the field as a Date field in Excel.

However currently tabulator does JSON.stringify on the object therefore the actual Date object is never passed to XLSX.utils.sheet_add_aoa.

This pull request checks if the field is a Date object and therefore doesnt JSON.stringify, resulting in Excel opening the xlsx and the field being shown as a Date field.