### PR TITLE
On header filter selects - show x to clear filter

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -777,7 +777,8 @@ Edit.prototype.editors = {
 		input.style.padding = "4px";
 		input.style.width = "100%";
 		input.style.boxSizing = "border-box";
-		input.readOnly = true;
+		input.style.cursor = "default";
+		input.readOnly = (this.currentCell != false);
 
 		input.value = initialValue;
 


### PR DESCRIPTION
Hi,

With a readonly search input, there is no way of clearing the selection.

This is a problem for header filters that are a select field - as the user can't cancel / clear the selection.
see: http://tabulator.info/examples/4.2?#filter-header
Select a gender in the demo table, now you can't say 'show all' / clear as there is no x button (added by the browser for search inputs).

So this fix only adds readonly attribute if the filter is used within a editing cell, eg the gender column in this demo: http://tabulator.info/examples/4.2?#editable

But not if its a select is in a header filter.

I hope using  (this.currentCell != false) is correct thing to do to determine if its within a header filter or editable cell?

I added cursor = "default" to show its a select field not editable one, as this fix does mean the input is editable on the header filter, but i think this is fine as the user might want to type rather than select from a list.

Thanks,
alan