### PR TITLE
Convert string to Node for ajaxLoaderError option

### DIFF
--- a/src/js/modules/ajax.js
+++ b/src/js/modules/ajax.js
@@ -39,7 +39,13 @@ Ajax.prototype.initialize = function(){
 	this.urlGenerator = this.table.options.ajaxURLGenerator || this.defaultURLGenerator;
 
 	if(this.table.options.ajaxLoaderError){
-		this.errorElement = this.table.options.ajaxLoaderError;
+		if(typeof this.table.options.ajaxLoaderError == "string"){
+			template = document.createElement('template');
+			template.innerHTML = this.table.options.ajaxLoaderError.trim();
+			this.errorElement = template.content.firstChild;
+		}else{
+			this.errorElement = this.table.options.ajaxLoaderError;
+		}
 	}
 
 	if(this.table.options.ajaxParams){


### PR DESCRIPTION
Closes #1916 

This PR converts a string of HTML to a Node for the `ajaxLoaderError` option, the same way you are currently doing it for the `ajaxLoaderLoading` option. 