### PR TITLE
closes #1940: arrow keys in "select editor" scrolls the editor grid

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -795,6 +795,7 @@ Edit.prototype.editors = {
 				case 38: //up arrow
 				e.stopImmediatePropagation();
 				e.stopPropagation();
+				e.preventDefault();
 
 				index = dataItems.indexOf(currentItem);
 
@@ -806,6 +807,7 @@ Edit.prototype.editors = {
 				case 40: //down arrow
 				e.stopImmediatePropagation();
 				e.stopPropagation();
+				e.preventDefault();
 
 				index = dataItems.indexOf(currentItem);
 
@@ -816,6 +818,13 @@ Edit.prototype.editors = {
 						setCurrentItem(dataItems[index + 1]);
 					}
 				}
+				break;
+
+				case 37: //left arrow
+				case 39: //right arrow
+					e.stopImmediatePropagation();
+					e.stopPropagation();
+					e.preventDefault();
 				break;
 
 				case 13: //enter
@@ -1094,6 +1103,7 @@ Edit.prototype.editors = {
 				case 38: //up arrow
 				e.stopImmediatePropagation();
 				e.stopPropagation();
+				e.preventDefault();
 
 				index = displayItems.indexOf(currentItem);
 
@@ -1107,6 +1117,7 @@ Edit.prototype.editors = {
 				case 40: //down arrow
 				e.stopImmediatePropagation();
 				e.stopPropagation();
+				e.preventDefault();
 
 				index = displayItems.indexOf(currentItem);
 
@@ -1117,6 +1128,14 @@ Edit.prototype.editors = {
 						setCurrentItem(displayItems[index + 1]);
 					}
 				}
+				break;
+
+
+				case 37: //left arrow
+				case 39: //right arrow
+					e.stopImmediatePropagation();
+					e.stopPropagation();
+					e.preventDefault();
 				break;
 
 				case 13: //enter


### PR DESCRIPTION
* root cause: when using the up/down keys, the `keydown` event were bubbling up out of the select editor and being caught by either containing grid (or the window, if the grid doesn't have internal vertical scroll bars)
* solution: catch the event in the `keydown` event from bubbling up when using the arrow keys with in the editor
* also adding code to deal with the left/right keys to prevent the table from scrolling horizontally while the select editor is in focus
* extending the bug fix to the "autocomplete" editor as well