### PR TITLE
Replaced entity nbsp with UTF code (\u00a0)

### DIFF
--- a/src/js/column.js
+++ b/src/js/column.js
@@ -593,19 +593,19 @@ Column.prototype._buildColumnHeaderTitle = function(){
 
 		if(def.field){
 			table.modules.localize.bind("columns|" + def.field, function(text){
-				titleElement.value = text || (def.title || "&nbsp");
+				titleElement.value = text || (def.title || "\u00a0");
 			});
 		}else{
-			titleElement.value  = def.title || "&nbsp";
+			titleElement.value  = def.title || "\u00a0";
 		}
 
 	}else{
 		if(def.field){
 			table.modules.localize.bind("columns|" + def.field, function(text){
-				self._formatColumnHeaderTitle(titleHolderElement, text || (def.title || "&nbsp"));
+				self._formatColumnHeaderTitle(titleHolderElement, text || (def.title || "\u00a0"));
 			});
 		}else{
-			self._formatColumnHeaderTitle(titleHolderElement, def.title || "&nbsp");
+			self._formatColumnHeaderTitle(titleHolderElement, def.title || "\u00a0");
 		}
 	}
 

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -679,12 +679,12 @@ Edit.prototype.editors = {
 						el = document.createElement("div");
 						el.classList.add("tabulator-edit-select-list-group");
 						el.tabIndex = 0;
-						el.innerHTML = item.label === "" ? "&nbsp;" : item.label;
+						el.innerHTML = item.label === "" ? "\u00a0" : item.label;
 					}else{
 						el = document.createElement("div");
 						el.classList.add("tabulator-edit-select-list-item");
 						el.tabIndex = 0;
-						el.innerHTML = item.label === "" ? "&nbsp;" : item.label;
+						el.innerHTML = item.label === "" ? "\u00a0" : item.label;
 
 						el.addEventListener("click", function(){
 							setCurrentItem(item);
@@ -722,7 +722,7 @@ Edit.prototype.editors = {
 
 
 			currentItem = item;
-			input.value = item.label === "&nbsp;" ? "" : item.label;
+			input.value = item.label === "\u00a0" ? "" : item.label;
 
 			if(item.element){
 				item.element.classList.add("active");

--- a/src/js/modules/format.js
+++ b/src/js/modules/format.js
@@ -82,7 +82,7 @@ Format.prototype.sanitizeHTML = function(value){
 };
 
 Format.prototype.emptyToSpace = function(value){
-	return value === null || typeof value === "undefined" ? "&nbsp" : value;
+	return value === null || typeof value === "undefined" ? "\u00a0" : value;
 };
 
 //get formatter for cell


### PR DESCRIPTION
Using entity name "&nbsp" breaks initialization in XHTML pages in browsers that do not load the XHTML DTD (Chrome, in my case). I've simply replaced all occurrences of &nbsp with the UTF character code. Could not find any other html entities that aren't supported (eg. &lt; and &gt; works fine).

Note that I have **not** run any tests other than my own use-case. ("Works fine for me!")