### PR TITLE
[FEATURE] Add json string support for select editor params

### DIFF
--- a/dist/js/modules/edit.js
+++ b/dist/js/modules/edit.js
@@ -560,6 +560,10 @@ Edit.prototype.editors = {
 		    currentItem = {},
 		    blurable = true;
 
+		if (_typeof(editorParams) === "string") {
+			editorParams = JSON.parse(editorParams);
+		}
+
 		if (Array.isArray(editorParams) || !Array.isArray(editorParams) && (typeof editorParams === "undefined" ? "undefined" : _typeof(editorParams)) === "object" && !editorParams.values) {
 			console.warn("DEPRECATION WANRING - values for the select editor must now be passed into the values property of the editorParams object, not as the editorParams object");
 			editorParams = { values: editorParams };

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -555,6 +555,10 @@ Edit.prototype.editors = {
 		currentItem = {},
 		blurable = true;
 
+		if (_typeof(editorParams) === "string") {
+			editorParams = JSON.parse(editorParams);
+		}
+
 		if(Array.isArray(editorParams) || (!Array.isArray(editorParams) && typeof editorParams === "object" && !editorParams.values)){
 			console.warn("DEPRECATION WANRING - values for the select editor must now be passed into the values property of the editorParams object, not as the editorParams object");
 			editorParams = {values:editorParams};


### PR DESCRIPTION
Useful when using tabulator on an existing table so you can pass options as a JSON string.