### PR TITLE
Issue #2109 true for getDataCount() not respected.

### DIFF
--- a/src/js/row_manager.js
+++ b/src/js/row_manager.js
@@ -773,7 +773,7 @@ RowManager.prototype.getHtml = function(active){
 	}
 
 	RowManager.prototype.getDataCount = function(active){
-		return active ? this.rows.length : this.activeRows.length;
+		return active ? this.activeRows.length : this.rows.length;
 	};
 
 	RowManager.prototype._genRemoteRequest = function(){


### PR DESCRIPTION
Order of evaluation for active is backwards in row_manager.js for
getDataCount(). Fix by swapping order.