### PR TITLE
Fix missing reference to scroll header elements.

### DIFF
--- a/src/js/row_manager.js
+++ b/src/js/row_manager.js
@@ -864,6 +864,8 @@ RowManager.prototype.scrollHorizontal = function(left){
 	this.scrollLeft = left;
 	this.element.scrollLeft = left;
 
+	this.columnManager.scrollHorizontal(left);
+
 	if(this.table.options.groupBy){
 		this.table.modules.groupRows.scrollHeaders(left);
 	}


### PR DESCRIPTION
Closes #2137.

I know there were changes recently to update the header horizontal scroll position, but I think there was a reference that was missed.  The functionality of RowManager.scrollHorizontal() should match that of the "scroll" event handler.  The JSFiddle example in #2137 shows a particular situation where the scroll is not updated properly.