### PR TITLE
Fix bottomCalcParams crashing table

### DIFF
--- a/src/js/modules/calculation_colums.js
+++ b/src/js/modules/calculation_colums.js
@@ -297,7 +297,7 @@ ColumnCalcs.prototype.generateRowData = function(pos, data){
 			});
 
 			paramKey = type + "Params";
-			params = typeof column.modules.columnCalcs[paramKey] === "function" ? column.modules.columnCalcs[paramKey](value, data) : column.modules.columnCalcs[paramKey];
+			params = typeof column.modules.columnCalcs[paramKey] === "function" ? column.modules.columnCalcs[paramKey](values, data) : column.modules.columnCalcs[paramKey];
 
 			column.setFieldValue(rowData, column.modules.columnCalcs[type](values, data, params));
 		}


### PR DESCRIPTION
Fixed `bottomCalcParams` crashing table per issue #2161 

