### PR TITLE
Issue olifolkerd#2163. Navigation features broken.

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1612,7 +1612,7 @@ Tabulator.prototype.navigateDown = function(){
 
 		if(cell){
 			e.preventDefault();
-			return cell.nav().dpwn();
+			return cell.nav().down();
 		}
 	}
 


### PR DESCRIPTION
Change spelling from dpwn to down in Tabulator.prototype.navigateDown.