### PR TITLE
Issue #2166. The & operator has been used instead of && in validate.js.

### DIFF
--- a/src/js/modules/validate.js
+++ b/src/js/modules/validate.js
@@ -203,7 +203,7 @@ Validate.prototype.validators = {
 
 	//must have a value
 	required:function(cell, value, parameters){
-		return value !== "" & value !== null && typeof value !== "undefined";
+		return value !== "" && value !== null && typeof value !== "undefined";
 	},
 };
 


### PR DESCRIPTION
Add & to required:function to convert from bitwise to logical AND.