### PR TITLE
Issue  #2258. ReferenceError in RowManager.prototype.redraw when global `self` is not defined.

### DIFF
--- a/src/js/row_manager.js
+++ b/src/js/row_manager.js
@@ -1648,11 +1648,10 @@ RowManager.prototype.redraw = function (force){
 	this.table.tableWidth = this.table.element.clientWidth;
 
 	if(!force){
-                self = this;
-		if(self.renderMode == "classic"){
+		if(this.renderMode == "classic"){
 
-			if(self.table.options.groupBy){
-				self.refreshActiveData("group", false, false);
+			if(this.table.options.groupBy){
+				this.refreshActiveData("group", false, false);
 			}else{
 				this._simpleRender();
 			}

--- a/src/js/row_manager.js
+++ b/src/js/row_manager.js
@@ -1648,7 +1648,7 @@ RowManager.prototype.redraw = function (force){
 	this.table.tableWidth = this.table.element.clientWidth;
 
 	if(!force){
-
+                self = this;
 		if(self.renderMode == "classic"){
 
 			if(self.table.options.groupBy){


### PR DESCRIPTION
Issue #2258 
Add self = this in redraw() when in 'classic' renderMode.