### PR TITLE
Issue #2271. persistenceMode:true. 

### DIFF
--- a/src/js/modules/persistence.js
+++ b/src/js/modules/persistence.js
@@ -5,21 +5,25 @@ var Persistence = function(table){
 	this.persistProps = ["field", "width", "visible"];
 };
 
-//setup parameters
-Persistence.prototype.initialize = function(mode, id){
-	//determine persistent layout storage type
-	function lsTest(){
-            var  _tabulator_test =  "test";
+// Test for whether localStorage is available for use.
+Persistence.prototype.localStorageTest = function() {
+    function lsTest(){
+            var  testKey =  "_tabulator_test";
             try {
-                    window.localStorage.setItem( _tabulator_test, _tabulator_test);
-                    window.localStorage.removeItem( _tabulator_test);
+                    window.localStorage.setItem( testKey, testKey);
+                    window.localStorage.removeItem( testKey );
                     return true;
             } catch(e) {
                     return false;
-        }
-        }
-        var lStorage = lsTest();
-	this.mode = mode !== true ?  mode : (lStorage ? "local" : "cookie");
+            }
+        };
+};
+
+//setup parameters
+Persistence.prototype.initialize = function(mode, id){
+	//determine persistent layout storage type
+	
+	this.mode = mode !== true ?  mode : (this.localStorageTest() ? "local" : "cookie");
 
 	//set storage tag
 	this.id = "tabulator-" + (id || (this.table.element.getAttribute("id") || ""));

--- a/src/js/modules/persistence.js
+++ b/src/js/modules/persistence.js
@@ -8,7 +8,18 @@ var Persistence = function(table){
 //setup parameters
 Persistence.prototype.initialize = function(mode, id){
 	//determine persistent layout storage type
-	this.mode = mode !== true ?  mode : (typeof window.localStorage !== 'undefined' ? "local" : "cookie");
+	function lsTest(){
+            var test = 'test';
+            try {
+                    localStorage.setItem(test, test);
+                    localStorage.removeItem(test);
+                    return true;
+            } catch(e) {
+                    return false;
+        }
+        }
+        var lStorage = lsTest();
+	this.mode = mode !== true ?  mode : (lStorage ? "local" : "cookie");
 
 	//set storage tag
 	this.id = "tabulator-" + (id || (this.table.element.getAttribute("id") || ""));

--- a/src/js/modules/persistence.js
+++ b/src/js/modules/persistence.js
@@ -9,10 +9,10 @@ var Persistence = function(table){
 Persistence.prototype.initialize = function(mode, id){
 	//determine persistent layout storage type
 	function lsTest(){
-            var test = 'test';
+            var  _tabulator_test =  "test";
             try {
-                    localStorage.setItem(test, test);
-                    localStorage.removeItem(test);
+                    window.localStorage.setItem( _tabulator_test, _tabulator_test);
+                    window.localStorage.removeItem( _tabulator_test);
                     return true;
             } catch(e) {
                     return false;


### PR DESCRIPTION
Modify persistence.js to check for presence of localStorage. Previous code had this:
this.mode = mode !== true ?  mode : (typeof window.localStorage !== 'undefined' ? "local" : "cookie");
This did not do correct thing in FireFox when localStorage is disabled
as localStorage is set to null. window.localStorage !== 'undefined'
would resolve to true and mode 'local' would be selected even though
it was not available. Put in a generic test for localStorage
availability and use result to determine whether to use 'local' or
'cookie'.