### PR TITLE
_clearSelection performance issue

### DIFF
--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -21718,10 +21718,8 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 			if (self.table.options.selectable && self.table.options.selectable != "highlight") {
 				if (self.table.options.selectableRangeMode === "click") {
 					element.addEventListener("click", function (e) {
-
-						self.table._clearSelection();
-
 						if (e.shiftKey) {
+							self.table._clearSelection();
 							self.lastClickedRow = self.lastClickedRow || row;
 
 							var lastClickedRowIdx = self.table.rowManager.getDisplayRowIndex(self.lastClickedRow);
@@ -21758,6 +21756,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 								self.selectRows(toggledRows);
 							}
+							self.table._clearSelection();
 						} else if (e.ctrlKey || e.metaKey) {
 							self.toggleRow(row);
 							self.lastClickedRow = row;
@@ -21766,8 +21765,6 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 							self.selectRows(row);
 							self.lastClickedRow = row;
 						}
-
-						self.table._clearSelection();
 					});
 				} else {
 					element.addEventListener("click", function (e) {

--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -15701,7 +15701,11 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 		this.headerFilters = {};
 
-		this.headerFilterColumns.forEach(function (column) {
+		var oldHeaderFilterColumns = this.headerFilterColumns;
+		this.headerFilterColumns = [];
+		this.headerFilterElements = [];
+
+		oldHeaderFilterColumns.forEach(function (column) {
 			column.modules.filter.value = null;
 			column.modules.filter.prevSuccess = undefined;
 			self.reloadHeaderFilter(column);

--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -15701,11 +15701,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 		this.headerFilters = {};
 
-		var oldHeaderFilterColumns = this.headerFilterColumns;
-		this.headerFilterColumns = [];
-		this.headerFilterElements = [];
-
-		oldHeaderFilterColumns.forEach(function (column) {
+		this.headerFilterColumns.forEach(function (column) {
 			column.modules.filter.value = null;
 			column.modules.filter.prevSuccess = undefined;
 			self.reloadHeaderFilter(column);
@@ -21718,8 +21714,10 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 			if (self.table.options.selectable && self.table.options.selectable != "highlight") {
 				if (self.table.options.selectableRangeMode === "click") {
 					element.addEventListener("click", function (e) {
-						if (e.shiftKey) {
-							self.table._clearSelection();
+
+						self.table._clearSelection();
+
+						if (e.shiftKey) {							
 							self.lastClickedRow = self.lastClickedRow || row;
 
 							var lastClickedRowIdx = self.table.rowManager.getDisplayRowIndex(self.lastClickedRow);
@@ -21756,7 +21754,6 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 								self.selectRows(toggledRows);
 							}
-							self.table._clearSelection();
 						} else if (e.ctrlKey || e.metaKey) {
 							self.toggleRow(row);
 							self.lastClickedRow = row;
@@ -21765,6 +21762,8 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 							self.selectRows(row);
 							self.lastClickedRow = row;
 						}
+
+						self.table._clearSelection();
 					});
 				} else {
 					element.addEventListener("click", function (e) {

--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -21717,7 +21717,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 						self.table._clearSelection();
 
-						if (e.shiftKey) {							
+						if (e.shiftKey) {
 							self.lastClickedRow = self.lastClickedRow || row;
 
 							var lastClickedRowIdx = self.table.rowManager.getDisplayRowIndex(self.lastClickedRow);

--- a/src/js/modules/select_row.js
+++ b/src/js/modules/select_row.js
@@ -43,10 +43,8 @@ SelectRow.prototype.initializeRow = function(row){
 		if(self.table.options.selectable && self.table.options.selectable != "highlight"){
 			if(self.table.options.selectableRangeMode === "click"){
 				element.addEventListener("click", function(e){
-
-					self.table._clearSelection();
-
 					if(e.shiftKey){
+						self.table._clearSelection();
 						self.lastClickedRow = self.lastClickedRow || row;
 
 						var lastClickedRowIdx = self.table.rowManager.getDisplayRowIndex(self.lastClickedRow);
@@ -83,6 +81,7 @@ SelectRow.prototype.initializeRow = function(row){
 
 							self.selectRows(toggledRows);
 						}
+						self.table._clearSelection();
 					}
 					else if(e.ctrlKey || e.metaKey){
 						self.toggleRow(row);
@@ -92,8 +91,6 @@ SelectRow.prototype.initializeRow = function(row){
 						self.selectRows(row);
 						self.lastClickedRow = row;
 					}
-
-					self.table._clearSelection();
 				});
 			}else{
 				element.addEventListener("click", function(e){


### PR DESCRIPTION
Clearing text selection was slowing down the ordinary click row selection event on a large dataset in click selectableRangeMode. The default window text selection need only be cleared during a shift select.