### PR TITLE
Adding automatic group updates

### DIFF
--- a/src/js/cell.js
+++ b/src/js/cell.js
@@ -515,6 +515,10 @@ Cell.prototype.setValue = function(value, mutate){
 			this.column.cellEvents.cellEdited.call(this.table, component);
 		}
 
+		if(this.table.options.groupUpdateOnCellEdit && this.table.options.groupBy && this.table.modExists("groupRows")) {
+			this.table.modules.groupRows.reassignRowToGroup(this.row);
+		}
+		
 		this.cellRendered();
 
 		this.table.options.cellEdited.call(this.table, component);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -190,6 +190,7 @@ Tabulator.prototype.defaultOptions = {
 	groupBy:false, //enable table grouping and set field to group by
 	groupStartOpen:true, //starting state of group
 	groupValues:false,
+	groupUpdateOnCellEdit:false,
 
 	groupHeader:false, //header generation function
 

--- a/src/js/modules/group_rows.js
+++ b/src/js/modules/group_rows.js
@@ -54,6 +54,9 @@ GroupComponent.prototype.getTable = function(){
 	return this._group.groupManager.table;
 };
 
+GroupComponent.prototype.getPath = function() {
+	return this._group.getPath();
+}
 //////////////////////////////////////////////////
 //////////////// Group Functions /////////////////
 //////////////////////////////////////////////////
@@ -648,6 +651,12 @@ Group.prototype.generateGroupHeaderContents = function(){
 	this.element.insertBefore(this.arrowElement, this.element.firstChild);
 };
 
+Group.prototype.getPath = function(path = []) {
+	path.unshift(this.key);
+	if(this.parent) this.parent.getPath(path);
+
+	return path;
+}
 ////////////// Standard Row Functions //////////////
 
 Group.prototype.getElement = function(){
@@ -1040,7 +1049,31 @@ GroupRows.prototype.assignRowToGroup = function(row, oldGroups){
 	return !newGroupNeeded;
 };
 
+GroupRows.prototype.reassignRowToGroup = function(row){
+	var oldRowGroup = row.getGroup(),
+		oldGroupPath = oldRowGroup.getPath(),
+		newGroupPath = this.getExpectedPath(row),
+		samePath = true;
+	// figure out if new group path is the same as old group path
 
+	var samePath = (oldGroupPath.length == newGroupPath.length) && oldGroupPath.every(function(element, index) {
+		return element === newGroupPath[index]; 
+	});
+	// refresh if they new path and old path aren't the same (aka the row's groupings have changed)
+	if(!samePath) {
+		oldRowGroup.removeRow(row);
+		this.assignRowToGroup(row, self.groups);
+		this.updateGroupRows(true);
+	}
+};
+
+GroupRows.prototype.getExpectedPath = function(row) {
+	var groupPath = [], rowData = row.getData();
+	this.groupIDLookups.forEach(function(groupId) {
+		groupPath.push(groupId.func(rowData));
+	});
+	return groupPath;
+}
 
 GroupRows.prototype.updateGroupRows = function(force){
 	var self = this,

--- a/src/js/modules/group_rows.js
+++ b/src/js/modules/group_rows.js
@@ -54,9 +54,6 @@ GroupComponent.prototype.getTable = function(){
 	return this._group.groupManager.table;
 };
 
-GroupComponent.prototype.getPath = function() {
-	return this._group.getPath();
-}
 //////////////////////////////////////////////////
 //////////////// Group Functions /////////////////
 //////////////////////////////////////////////////
@@ -653,8 +650,9 @@ Group.prototype.generateGroupHeaderContents = function(){
 
 Group.prototype.getPath = function(path = []) {
 	path.unshift(this.key);
-	if(this.parent) this.parent.getPath(path);
-
+	if(this.parent) {
+		this.parent.getPath(path);
+	}
 	return path;
 }
 ////////////// Standard Row Functions //////////////
@@ -1055,7 +1053,6 @@ GroupRows.prototype.reassignRowToGroup = function(row){
 		newGroupPath = this.getExpectedPath(row),
 		samePath = true;
 	// figure out if new group path is the same as old group path
-
 	var samePath = (oldGroupPath.length == newGroupPath.length) && oldGroupPath.every(function(element, index) {
 		return element === newGroupPath[index]; 
 	});
@@ -1063,7 +1060,7 @@ GroupRows.prototype.reassignRowToGroup = function(row){
 	if(!samePath) {
 		oldRowGroup.removeRow(row);
 		this.assignRowToGroup(row, self.groups);
-		this.updateGroupRows(true);
+		this.table.rowManager.refreshActiveData("group", false, true);
 	}
 };
 

--- a/src/js/row.js
+++ b/src/js/row.js
@@ -571,6 +571,10 @@ Row.prototype.updateData = function(updatedData){
 				}
 			});
 		}
+		
+		if(this.table.options.groupUpdateOnCellEdit && this.table.options.groupBy && this.table.modExists("groupRows")) {
+			this.table.modules.groupRows.reassignRowToGroup(this.row);
+		}
 
 		//Partial reinitialization if visible
 		if(visible){


### PR DESCRIPTION
This is an idea to resolve issue #1936. I am not sure if this is the best place to put this, but it does seem like a catch-all area for both user-based updates and code-based updates. 

Let me know what you think or if you would like any explanation. 

Thanks!

Edit: I guess I should explain:

I took into consideration that you could have multiple levels of groups and that not every update on a value that update the groups. This change will first check the possible new "path" to the bottom-most group, and then builds in-reverse the current path by checking the group parents. It compares the 2 paths and only redraws the table if the paths are not the same. 

I'm not sure if this the best way to redraw the table... so please let me know!