### PR TITLE
Fixed missing highlight color (for selected rows) in the new materialize design

### DIFF
--- a/src/scss/materialize/variables.scss
+++ b/src/scss/materialize/variables.scss
@@ -46,6 +46,23 @@ $materialize-red: (
   "darken-4":   #8b1014,
 );
 
+$colors: (
+        "materialize-red": $materialize-red,
+) !default;
+
+// usage: color("name_of_color", "type_of_color")
+// to avoid to repeating map-get($colors, ...)
+@function color($color, $type) {
+  @if map-has-key($colors, $color) {
+    $curr_color: map-get($colors, $color);
+    @if map-has-key($curr_color, $type) {
+      @return map-get($curr_color, $type);
+    }
+  }
+  @warn "Unknown `#{$color}` - `#{$type}` in $colors.";
+  @return null;
+}
+
 $table-border-color: rgba(0,0,0,.12) !default;
 $table-striped-color: rgba(242, 242, 242, 0.5) !default;
 


### PR DESCRIPTION
Selecting a row would not change the color. I added the missing snippets from the materialize-css so it works correctly.