### PR TITLE
Improved sorting performance when sorting on multiple columns

### DIFF
--- a/src/js/modules/sort.js
+++ b/src/js/modules/sort.js
@@ -228,6 +228,9 @@ Sort.prototype.sort = function(data){
 
 	if(!self.table.options.ajaxSorting){
 
+		var lastPossibleIndex = -1;
+
+		// iterate over the sortList to find the last possible sorting column (i.e. column that is actually valid for sorting)
 		sortList.forEach(function(item, i){
 
 			if(item.column && item.column.modules.sort){
@@ -237,11 +240,17 @@ Sort.prototype.sort = function(data){
 					item.column.modules.sort.sorter = self.findSorter(item.column);
 				}
 
-				self._sortItem(data, item.column, item.dir, sortList, i);
+				lastPossibleIndex = i;
 			}
 
 			self.setColumnHeader(item.column, item.dir);
 		});
+
+		// Note: since the sorting-function falls back to previous columns if the result of the given column is equal, we only have to sort the data once
+		if (lastPossibleIndex > -1) {
+			self._sortItem(data, sortList[lastPossibleIndex].column, sortList[lastPossibleIndex].dir, sortList, lastPossibleIndex);
+		}
+
 	}else{
 		sortList.forEach(function(item, i){
 			self.setColumnHeader(item.column, item.dir);


### PR DESCRIPTION
The current implementation for sorting on multiple columns seems to be unnecessary slow. It will call the sort-Function on the data-array once for each sorter (i.e. item in the sortList).
However, only one (!) call is actually needed: the last one.

There are two reasons for this:
* a) the last call to sort will "overwrite" the previous sorting anyways
* b) the comparator used in the actual sorting-algorithm falls back to the previous columns in case the current comparison result was 0 (=equal) -> this already fully handles the multi-sort
