### PR TITLE
adding in the ability to set initial layouts

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -60,6 +60,7 @@ Tabulator.prototype.defaultOptions = {
 	initialSort:false, //initial sorting criteria
 	initialFilter:false, //initial filtering criteria
 	initialHeaderFilter:false, //initial header filtering criteria
+	initialLayout:false, //initial layout criteria
 
 	columnHeaderSortMulti: true, //multiple or single column sorting
 
@@ -507,6 +508,9 @@ Tabulator.prototype._buildElement = function(){
 		this.modules.frozenRows.initialize();
 	}
 
+	if(options.initialLayout && this.modExists("persistence", true)){
+		this.columnManager.setColumns(this.modules.persistence.mergeDefinition(options.columns, options.initialLayout));
+	}
 	if((options.persistentSort || options.initialSort) && this.modExists("sort", true)){
 		var sorters = [];
 


### PR DESCRIPTION
I'd like to see if you want this new feature.

I've made it so that I can pass in a layout as an option. Previously, I was setting the layout and sort after the table was created which was 2-3 times slower than creating the table without sorters or saved layout. The layout needs to be set before the sort. It's much faster and my users will probably enjoy that.

@olifolkerd if you want me to try to add in the persistence like you have for sort and filters I would be happy to add more commits to this PR for it. I thought it would be nice to run this feature idea past you before I just go crazy and add stuff.