### PR TITLE
Fixing a TypeError that was thrown inside a Promise and was uncaught

### DIFF
--- a/src/js/modules/page.js
+++ b/src/js/modules/page.js
@@ -474,7 +474,10 @@ Page.prototype.getRows = function(data){
 Page.prototype.trigger = function(){
 	var left;
 
-	return new Promise((resolve, reject)=>{
+	return new Promise((resolve, reject) => {
+		if (!this.table) {
+			throw new Error("we're too early, table not constructed yet!");
+		}
 
 		switch(this.mode){
 			case "local":


### PR DESCRIPTION
Hi,

I am using Tabulator in an internal application developed for large, international bank. We're using it with LitElement/WebComponents and most of the time it works just fine, awesome job ;) Today I noticed error messages in developers console, saying that `Uncaught (in promise)`. So I started hunting. It appears that pagination tries to set a Page when the table is not yet ready. The root cause of the issue was line 487 of `src/js/modules/page.js`:

```javascript
left = this.table.rowManager.scrollLeft;
```

In the code above, `this.table` was `undefined`, which caused an uncaught `TypeError`. I added a check at the beginning of the function and I explicitely throw an `Error`. Why? Because this is inside a `Promise`, so it will be caught in the caller. I think this solution is clean and it resolves my issue.

BTW problem was not visible otherwise; I only noticed it because of a message in Chrome Developer Tools :)