### PR TITLE
Fix typo in layout.js

### DIFF
--- a/src/js/modules/layout.js
+++ b/src/js/modules/layout.js
@@ -82,7 +82,7 @@ Layout.prototype.modes = {
 			if(gap > 0){
 				lastCol.setWidth(gap);
 			}else{
-				column.reinitializeWidth();
+				lastCol.reinitializeWidth();
 			}
 		}else{
 			if(this.table.options.responsiveLayout && this.table.modExists("responsiveLayout", true)){


### PR DESCRIPTION
With the typo in place, when table does not fit in window, tabulator renders no content at all and following exception is thrown:

    Uncaught ReferenceError: column is not defined

If the table does fit in window,  several exceptions are thrown:

    Uncaught ReferenceError: column is not defined
    Uncaught (in promise) ReferenceError: column is not defined
    Uncaught (in promise) undefined