### PR TITLE
#2584 Add top and bottom row calcs during xlsx export when row groups are applied

### DIFF
--- a/src/js/modules/calculation_colums.js
+++ b/src/js/modules/calculation_colums.js
@@ -334,7 +334,10 @@ ColumnCalcs.prototype.redraw = function(){
 //return the calculated
 ColumnCalcs.prototype.getResults = function(){
 	var self = this,
-	results = {},
+	results = {
+		top: this.topRow ? this.topRow.getData() : {},
+		bottom: this.botRow ? this.botRow.getData() : {},
+	},
 	groups;
 
 	if(this.table.options.groupBy && this.table.modExists("groupRows")){
@@ -343,11 +346,6 @@ ColumnCalcs.prototype.getResults = function(){
 		groups.forEach(function(group){
 			results[group.getKey()] = self.getGroupResults(group);
 		});
-	}else{
-		results = {
-			top: this.topRow ? this.topRow.getData() : {},
-			bottom: this.botRow ? this.botRow.getData() : {},
-		}
 	}
 
 	return results;

--- a/src/js/modules/download.js
+++ b/src/js/modules/download.js
@@ -869,20 +869,20 @@ Download.prototype.downloaders = {
 
 			}
 
+			if(config.columnCalcs){
+				addCalcRow(calcs, "top");
+			}
+
 			if(config.rowGroups){
 				data.forEach(function(group){
 					parseGroup(group, calcs);
 				});
 			}else{
-				if(config.columnCalcs){
-					addCalcRow(calcs, "top");
-				}
-
 				parseRows(data);
+			}
 
-				if(config.columnCalcs){
-					addCalcRow(calcs, "bottom");
-				}
+			if(config.columnCalcs){
+				addCalcRow(calcs, "bottom");
 			}
 
 			worksheet = rowsToSheet();


### PR DESCRIPTION
This is a fix for pull request https://github.com/olifolkerd/tabulator/issues/2584