### PR TITLE
feat: detect meta key keybinding

### DIFF
--- a/src/js/modules/keybindings.js
+++ b/src/js/modules/keybindings.js
@@ -63,6 +63,7 @@ Keybindings.prototype.mapBinding = function(action, symbolsList){
 		keys: [],
 		ctrl: false,
 		shift: false,
+		meta: false,
 	};
 
 	var symbols = symbolsList.toString().toLowerCase().split(" ").join("").split("+");
@@ -75,6 +76,10 @@ Keybindings.prototype.mapBinding = function(action, symbolsList){
 
 			case "shift":
 			binding.shift = true;
+			break;
+
+			case "meta":
+			binding.meta = true;
 			break;
 
 			default:
@@ -141,7 +146,7 @@ Keybindings.prototype.checkBinding = function(e, binding){
 	var self = this,
 	match = true;
 
-	if(e.ctrlKey == binding.ctrl && e.shiftKey == binding.shift){
+	if(e.ctrlKey == binding.ctrl && e.shiftKey == binding.shift && e.metaKey == binding.meta){
 		binding.keys.forEach(function(key){
 			var index = self.pressedKeys.indexOf(key);
 


### PR DESCRIPTION
Hi!

This PR adds the ability to use the "meta" key for keybindings.
The "meta" key corresponds to the command key on MacOS and the Windows key on Windows.

This is useful to create a keyboard shortcut preserving the OS keyboard behavior.
For example to select all rows with CRTL+A on Windows and CMD+A on MacOS:

```javascript
// Actions
Tabulator.prototype.extendModule('keybindings', 'actions', {,
  selectAllRows: function(event: KeyboardEvent) {
    event.preventDefault();
    this.table.selectRow();
  },
});
```

```javascript
// Keybindings
Tabulator.prototype.extendModule('keybindings', 'bindings', {
  selectAllRows: IS_MAC ? 'meta + 65' : 'ctrl + 65',
});
```

Thank you