### PR TITLE
Fix Shift+Tab navigation for Number and Range editors

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -462,7 +462,6 @@ Edit.prototype.editors = {
 		input.addEventListener("keydown", function(e){
 			switch(e.keyCode){
 				case 13:
-				case 9:
 				onChange();
 				break;
 
@@ -530,7 +529,6 @@ Edit.prototype.editors = {
 		input.addEventListener("keydown", function(e){
 			switch(e.keyCode){
 				case 13:
-				case 9:
 				onChange();
 				break;
 


### PR DESCRIPTION
The 'number' and 'range' cell editors do not follow the convention when using Shift+Tab to move to the previous cell.  Instead, focus remains in the cell.  Removing the onChange keyhandler for the Shift (keycode 9) key allows it to work as expected.