### PR TITLE
Fix 'range' editor preventing Shift+Tab

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -617,7 +617,7 @@ Edit.prototype.editors = {
 		input.addEventListener("keydown", function(e){
 			switch(e.keyCode){
 				case 13:
-				case 9:
+				// case 9:
 				onChange();
 				break;
 


### PR DESCRIPTION
Using the key combination Shift+Tab in the 'range' editor keeps the focus in the editor instead of moving to the previous editable cell.

I commented out the code, as you did in the case of the 'number' editor, which originally had the same issue.