### PR TITLE
If the cell value is an array do not stringify it, instead use the ar…

### DIFF
--- a/src/js/modules/download.js
+++ b/src/js/modules/download.js
@@ -818,7 +818,12 @@ Download.prototype.downloaders = {
 
 				fields.forEach(function(field){
 					var value = self.getFieldValue(field, row);
-					rowData.push(!(value instanceof Date) && typeof value === "object" ? JSON.stringify(value) : value);
+					if(Array.isArray(value)){
+						rowData.push(value);
+					}
+					else{
+						rowData.push(!(value instanceof Date) && typeof value === "object" ? JSON.stringify(value) : value);
+					}
 				});
 
 				return rowData;


### PR DESCRIPTION
Updated PR with isolated changes supporting cell formulas.

This puts the requirement on the user to format their data how they wish for it to be displayed when using an array.