### PR TITLE
allow escape key press to close context menus

### DIFF
--- a/src/js/modules/menu.js
+++ b/src/js/modules/menu.js
@@ -2,6 +2,7 @@ var Menu = function(table){
 	this.table = table; //hold Tabulator object
 	this.menuEl = false;
 	this.blurEvent = this.hideMenu.bind(this);
+	this.escEvent = this.escMenu.bind(this);
 };
 
 Menu.prototype.initializeColumnHeader = function(column){
@@ -120,6 +121,8 @@ Menu.prototype.loadMenu = function(e, component, menu){
 		document.body.addEventListener("contextmenu", this.blurEvent);
 	}, 100);
 
+	document.body.addEventListener("keydown", this.escEvent);
+
 	document.body.appendChild(this.menuEl);
 
 	//move menu to start on right edge if it is too close to the edge of the screen
@@ -135,9 +138,19 @@ Menu.prototype.loadMenu = function(e, component, menu){
 	}
 };
 
+Menu.prototype.escMenu = function(event){
+	if(event.key === "Escape"){
+		this.hideMenu();
+	}
+};
+
 Menu.prototype.hideMenu = function(){
 	if(this.menuEl.parentNode){
 		this.menuEl.parentNode.removeChild(this.menuEl);
+	}
+
+	if(this.escEvent){
+		document.body.removeEventListener("keydown", this.escEvent);
 	}
 
 	if(this.blurEvent){

--- a/src/js/modules/menu.js
+++ b/src/js/modules/menu.js
@@ -138,8 +138,8 @@ Menu.prototype.loadMenu = function(e, component, menu){
 	}
 };
 
-Menu.prototype.escMenu = function(event){
-	if(event.key === "Escape"){
+Menu.prototype.escMenu = function(e){
+	if(e.keyCode == 27){
 		this.hideMenu();
 	}
 };


### PR DESCRIPTION
This PR adds a keydown event listener so that the escape key can be used to close context menus.  This corresponds with the feature request issue: https://github.com/olifolkerd/tabulator/issues/2807