### PR TITLE
allow table access in downloadDataFormatter

### DIFF
--- a/src/js/modules/download.js
+++ b/src/js/modules/download.js
@@ -220,6 +220,7 @@ Download.prototype.processData = function(active){
 
 	//bulk data processing
 	if(typeof self.table.options.downloadDataFormatter == "function"){
+		data.table = self.table;
 		data = self.table.options.downloadDataFormatter(data);
 	}
 


### PR DESCRIPTION
This small addition allows downloadDataFormatters to access the table so they can make more informed formatting decisions.  It corresponds with feature request issue: https://github.com/olifolkerd/tabulator/issues/2810