### PR TITLE
TYPO: change 'Defintion' to 'Definition'

### DIFF
--- a/src/js/column.js
+++ b/src/js/column.js
@@ -1335,8 +1335,8 @@ Column.prototype.updateDefinition = function(updates){
 				reject(err);
 			});
 		}else{
-			console.warn("Column Update Error - The updateDefintion function is only available on columns, not column groups");
-			reject("Column Update Error - The updateDefintion function is only available on columns, not column groups");
+			console.warn("Column Update Error - The updateDefinition function is only available on columns, not column groups");
+			reject("Column Update Error - The updateDefinition function is only available on columns, not column groups");
 		}
 	});
 };


### PR DESCRIPTION
Hello Oli, 

I have found a typo. 

You also make this typo a few times in the documentation. At least I could find it here: http://www.tabulator.info/docs/4.7/columns

It doesn't seem the documentation is hosted in this repo though. 

Hielke