### PR TITLE
fix: home/end key capture issue

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -535,7 +535,7 @@ Edit.prototype.editors = {
 	textarea:function(cell, onRendered, success, cancel, editorParams){
 		var self = this,
 		cellValue = cell.getValue(),
-		vertNav = editorParams.verticalNavigation || "hybrid",
+    vertNav = editorParams.verticalNavigation || "hybrid",
 		value = String(cellValue !== null && typeof cellValue !== "undefined"  ? cellValue : ""),
 		count = (value.match(/(?:\r\n|\r|\n)/g) || []).length + 1,
 		input = document.createElement("textarea"),
@@ -607,7 +607,17 @@ Edit.prototype.editors = {
         	switch(e.keyCode){
         		case 27:
         		cancel();
-        		break;
+            break;
+            
+            case 36: // home
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            break;
+
+            case 35: // end
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            break;
 
         		case 38: //up arrow
         		if(vertNav == "editor" || (vertNav == "hybrid" && input.selectionStart)){

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -535,7 +535,7 @@ Edit.prototype.editors = {
 	textarea:function(cell, onRendered, success, cancel, editorParams){
 		var self = this,
 		cellValue = cell.getValue(),
-    vertNav = editorParams.verticalNavigation || "hybrid",
+		vertNav = editorParams.verticalNavigation || "hybrid",
 		value = String(cellValue !== null && typeof cellValue !== "undefined"  ? cellValue : ""),
 		count = (value.match(/(?:\r\n|\r|\n)/g) || []).length + 1,
 		input = document.createElement("textarea"),
@@ -607,8 +607,8 @@ Edit.prototype.editors = {
         	switch(e.keyCode){
         		case 27:
         		cancel();
-            break;
-            
+						break;
+
         		case 38: //up arrow
         		if(vertNav == "editor" || (vertNav == "hybrid" && input.selectionStart)){
         			e.stopImmediatePropagation();

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -607,7 +607,7 @@ Edit.prototype.editors = {
         	switch(e.keyCode){
         		case 27:
         		cancel();
-						break;
+        		break;
 
         		case 38: //up arrow
         		if(vertNav == "editor" || (vertNav == "hybrid" && input.selectionStart)){

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -609,16 +609,6 @@ Edit.prototype.editors = {
         		cancel();
             break;
             
-            case 36: // home
-            e.stopImmediatePropagation();
-            e.stopPropagation();
-            break;
-
-            case 35: // end
-            e.stopImmediatePropagation();
-            e.stopPropagation();
-            break;
-
         		case 38: //up arrow
         		if(vertNav == "editor" || (vertNav == "hybrid" && input.selectionStart)){
         			e.stopImmediatePropagation();

--- a/src/js/modules/keybindings.js
+++ b/src/js/modules/keybindings.js
@@ -187,6 +187,11 @@ Keybindings.prototype.actions = {
 		e.preventDefault();
 	},
 	scrollPageUp:function(e){
+
+    if (this.table.modExists("edit")) {
+      return;
+    }
+
 		var rowManager = this.table.rowManager,
 		newPos = rowManager.scrollTop - rowManager.height,
 		scrollMax = rowManager.element.scrollHeight;
@@ -204,7 +209,12 @@ Keybindings.prototype.actions = {
 		this.table.element.focus();
 	},
 	scrollPageDown:function(e){
-		var rowManager = this.table.rowManager,
+
+    if (this.table.modExists("edit")) {
+      return;
+    }
+
+    var rowManager = this.table.rowManager,
 		newPos = rowManager.scrollTop + rowManager.height,
 		scrollMax = rowManager.element.scrollHeight;
 
@@ -222,7 +232,13 @@ Keybindings.prototype.actions = {
 
 	},
 	scrollToStart:function(e){
-		var rowManager = this.table.rowManager;
+
+    if (this.table.modExists("edit")) {
+      return;
+    }
+
+
+    var rowManager = this.table.rowManager;
 
 		e.preventDefault();
 
@@ -233,7 +249,13 @@ Keybindings.prototype.actions = {
 		this.table.element.focus();
 	},
 	scrollToEnd:function(e){
-		var rowManager = this.table.rowManager;
+
+    if (this.table.modExists("edit")) {
+      return;
+    }
+
+
+    var rowManager = this.table.rowManager;
 
 		e.preventDefault();
 

--- a/src/js/modules/keybindings.js
+++ b/src/js/modules/keybindings.js
@@ -188,9 +188,9 @@ Keybindings.prototype.actions = {
 	},
 	scrollPageUp:function(e){
 
-    if (this.table.modExists("edit")) {
-      return;
-    }
+		if (this.table.modExists("edit")) {
+			return;
+		}
 
 		var rowManager = this.table.rowManager,
 		newPos = rowManager.scrollTop - rowManager.height,
@@ -210,11 +210,11 @@ Keybindings.prototype.actions = {
 	},
 	scrollPageDown:function(e){
 
-    if (this.table.modExists("edit")) {
-      return;
-    }
+		if (this.table.modExists("edit")) {
+			return;
+		}
 
-    var rowManager = this.table.rowManager,
+		var rowManager = this.table.rowManager,
 		newPos = rowManager.scrollTop + rowManager.height,
 		scrollMax = rowManager.element.scrollHeight;
 
@@ -233,12 +233,12 @@ Keybindings.prototype.actions = {
 	},
 	scrollToStart:function(e){
 
-    if (this.table.modExists("edit")) {
-      return;
-    }
+		if (this.table.modExists("edit")) {
+			return;
+		}
 
 
-    var rowManager = this.table.rowManager;
+		var rowManager = this.table.rowManager;
 
 		e.preventDefault();
 
@@ -250,12 +250,12 @@ Keybindings.prototype.actions = {
 	},
 	scrollToEnd:function(e){
 
-    if (this.table.modExists("edit")) {
-      return;
-    }
+		if (this.table.modExists("edit")) {
+			return;
+		}
 
 
-    var rowManager = this.table.rowManager;
+		var rowManager = this.table.rowManager;
 
 		e.preventDefault();
 


### PR DESCRIPTION
fixes #2945.

If you are in edit mode the table will not scroll up or down if you press the keyboard shortcuts.

I think this is desirable behavior as currently it just cancels you out of editing. 

Questions: 
- Should this be behind a flag to turn it on?
- Should this be the existing `verticalNavigation` key maybe? It's not really the same issue
