### PR TITLE
formatter: add support for suffix/prefix to the image formatter

### DIFF
--- a/src/js/modules/format.js
+++ b/src/js/modules/format.js
@@ -277,8 +277,18 @@ Format.prototype.formatters = {
 
 	//image element
 	image:function(cell, formatterParams, onRendered){
-		var el = document.createElement("img");
-		el.setAttribute("src", cell.getValue());
+		var el = document.createElement("img"),
+		    src = cell.getValue();
+
+		if(formatterParams.urlPrefix){
+			src = formatterParams.urlPrefix + cell.getValue();
+		}
+
+		if(formatterParams.urlSuffix){
+			src = src + formatterParams.urlSuffix;
+		}
+
+		el.setAttribute("src", src);
 
 		switch(typeof formatterParams.height){
 			case "number":


### PR DESCRIPTION
I found that the image formatter required a full URL to the image. 
In my experience images were well organized /something/<productid> , so I want to reuse that id field to display the image. Just need to add the prefix/suffix. 

Bonus: Some CDN and application frameworks support automated resizing of images by adding something like ?width=123. This can be used easily with a suffix.

Usage:

```
        {title:"image", field:"id", width:120, formatter:"image", formatterParams:{urlPrefix:"/images/product/", urlSuffix:".jpg", width:"100%"},
        {title:"otherimage", field:"id", width:120, formatter:"image", formatterParams:{urlSuffix:"?w=256", width:"100%"},
```