### PR TITLE
added support to autoSelectFirstItem of the autocomplete editor

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -1601,12 +1601,13 @@ Edit.prototype.editors = {
 
 		function fillList(items, intialLoad){
 			var current = false;
+			var autoSelectIndex = -1;
 
 			clearList();
 
 			displayItems = items;
 
-			displayItems.forEach(function(item){
+			displayItems.forEach(function(item, idx){
 				var el = item.element;
 
 				if(!el){
@@ -1631,9 +1632,7 @@ Edit.prototype.editors = {
 					item.element = el;
 
 					if(intialLoad && item.value == initialValue){
-						input.value = item.title;
-						item.element.classList.add("active");
-						current = true;
+						autoSelectIndex = idx;
 					}
 
 					if(item === currentItem){
@@ -1646,7 +1645,9 @@ Edit.prototype.editors = {
 			});
 
 			if(!current){
-				if (editorParams.autoSelectFirstItem) {
+				if (autoSelectIndex >= 0) {
+					setCurrentItem(displayItems[autoSelectIndex]);
+				} else if (editorParams.autoSelectFirstItem) {
 					setCurrentItem(displayItems[0]);
 				} else {
 					setCurrentItem(false);

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -1646,7 +1646,11 @@ Edit.prototype.editors = {
 			});
 
 			if(!current){
-				setCurrentItem(false);
+				if (editorParams.autoSelectFirstItem) {
+					setCurrentItem(displayItems[0]);
+				} else {
+					setCurrentItem(false);
+				}
 			}
 		}
 

--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -1601,7 +1601,7 @@ Edit.prototype.editors = {
 
 		function fillList(items, intialLoad){
 			var current = false;
-			var autoSelectIndex = -1;
+			var autoSelectIndex = editorParams.autoSelectFirstItem ? 0 : -1;
 
 			clearList();
 
@@ -1647,8 +1647,6 @@ Edit.prototype.editors = {
 			if(!current){
 				if (autoSelectIndex >= 0) {
 					setCurrentItem(displayItems[autoSelectIndex]);
-				} else if (editorParams.autoSelectFirstItem) {
-					setCurrentItem(displayItems[0]);
 				} else {
 					setCurrentItem(false);
 				}


### PR DESCRIPTION
This change resolves the feature request: [https://github.com/olifolkerd/tabulator/issues/2906](url)

I apologize if I have not followed some best practice in the GitHub world (this is my first GitHub pull request).

Should the documentation also be updated connected to the change (since a new property of the editorParams is added)?

Best regards,

Leif