### PR TITLE
Fix localisation not working in collapsed column titles

### DIFF
--- a/src/js/modules/responsive_layout.js
+++ b/src/js/modules/responsive_layout.js
@@ -249,11 +249,13 @@ ResponsiveLayout.prototype.generateCollapsedRowData = function(row){
 				};
 
 				output.push({
+					field: column.field,
 					title: column.definition.title,
 					value: column.modules.format.formatter.call(self.table.modules.format, mockCellComponent, column.modules.format.params)
 				});
 			}else{
 				output.push({
+					field: column.field,
 					title: column.definition.title,
 					value: value
 				});
@@ -267,6 +269,7 @@ ResponsiveLayout.prototype.generateCollapsedRowData = function(row){
 ResponsiveLayout.prototype.formatCollapsedData = function(data){
 	var list = document.createElement("table"),
 	listContents = "";
+	let columns = this.table.modules.localize.lang.columns;
 
 	data.forEach(function(item){
 		var div = document.createElement("div");
@@ -276,7 +279,7 @@ ResponsiveLayout.prototype.formatCollapsedData = function(data){
 			item.value = div.innerHTML;
 		}
 
-		listContents += "<tr><td><strong>" + item.title + "</strong></td><td>" + item.value + "</td></tr>";
+		listContents += "<tr><td><strong>" + (columns[item.field] || item.title) + "</strong></td><td>" + item.value + "</td></tr>";
 	});
 
 	list.innerHTML = listContents;

--- a/src/js/modules/responsive_layout.js
+++ b/src/js/modules/responsive_layout.js
@@ -267,22 +267,31 @@ ResponsiveLayout.prototype.generateCollapsedRowData = function(row){
 };
 
 ResponsiveLayout.prototype.formatCollapsedData = function(data){
-	var list = document.createElement("table"),
-	listContents = "";
-	let columns = this.table.modules.localize.lang.columns;
+	var list = document.createElement("table");
 
 	data.forEach(function(item){
-		var div = document.createElement("div");
+		var row = document.createElement("tr");
+		var titleData = document.createElement("td");
+		var valueData = document.createElement("td");
+		list.appendChild(row);
+		row.appendChild(titleData);
+		row.appendChild(valueData);
+
+		var titleHighlight = document.createElement("strong");
+		titleData.appendChild(titleHighlight);
+		this.table.modules.localize.bind("columns|" + item.field, function(text){
+			titleHighlight.innerText = text || item.title;
+		});
+
 
 		if(item.value instanceof Node){
+			var div = document.createElement("div");
 			div.appendChild(item.value);
-			item.value = div.innerHTML;
+			valueData.appendChild(div);
+		}else{
+			valueData.innerHTML = item.value;
 		}
-
-		listContents += "<tr><td><strong>" + (columns[item.field] || item.title) + "</strong></td><td>" + item.value + "</td></tr>";
-	});
-
-	list.innerHTML = listContents;
+	}, this);
 
 	return Object.keys(data).length ? list : "";
 };

--- a/src/js/modules/responsive_layout.js
+++ b/src/js/modules/responsive_layout.js
@@ -273,9 +273,7 @@ ResponsiveLayout.prototype.formatCollapsedData = function(data){
 		var row = document.createElement("tr");
 		var titleData = document.createElement("td");
 		var valueData = document.createElement("td");
-		list.appendChild(row);
-		row.appendChild(titleData);
-		row.appendChild(valueData);
+		var node_content;
 
 		var titleHighlight = document.createElement("strong");
 		titleData.appendChild(titleHighlight);
@@ -283,14 +281,17 @@ ResponsiveLayout.prototype.formatCollapsedData = function(data){
 			titleHighlight.innerText = text || item.title;
 		});
 
-
 		if(item.value instanceof Node){
-			var div = document.createElement("div");
-			div.appendChild(item.value);
-			valueData.appendChild(div);
+			node_content = document.createElement("div");
+			node_content.appendChild(item.value);
+			valueData.appendChild(node_content);
 		}else{
 			valueData.innerHTML = item.value;
 		}
+
+		row.appendChild(titleData);
+		row.appendChild(valueData);
+		list.appendChild(row);
 	}, this);
 
 	return Object.keys(data).length ? list : "";


### PR DESCRIPTION
Hi,

here's a PR in lieu of a bug report.
Localised header names revert back to the default title when collapsed. See: https://jsfiddle.net/ckqsL9je/

If there's a better way of getting the translated title, please feel free to edit this.
item.title is kept for backwards compatibility and fallback purposes.