### PR TITLE
fix: 🐛 Use floating numbers for cell width

### DIFF
--- a/src/js/cell.js
+++ b/src/js/cell.js
@@ -663,7 +663,7 @@ Cell.prototype.clearWidth = function(){
 };
 
 Cell.prototype.getWidth = function(){
-	return this.width || this.element.offsetWidth;
+	return this.width || this.element.getBoundingClientRect().width;
 };
 
 Cell.prototype.setMinWidth = function(){

--- a/src/js/column.js
+++ b/src/js/column.js
@@ -1353,7 +1353,7 @@ Column.prototype.fitToData = function(){
 		});
 
 		if(maxWidth){
-			self.setWidthActual(maxWidth + 1);
+			self.setWidthActual(maxWidth);
 		}
 
 	}


### PR DESCRIPTION
There was an issue when using fitDataFill + first column frozen leading to having always a scrollbar, even though everything would fit on the screen.

By using the real width of the cell and not the rounded offsetWidth (see note here https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth), the tableRows will not become one to two pixel longer than the whole table, and scrollbars will only appear once nessecary.