### PR TITLE
Row selection fix for elements not yet initialized

### DIFF
--- a/src/js/modules/select_row.js
+++ b/src/js/modules/select_row.js
@@ -218,6 +218,7 @@ SelectRow.prototype._selectRow = function(rowInfo, silent, force){
 
 	if(row){
 		if(this.selectedRows.indexOf(row) == -1){
+			row.getElement().classList.add("tabulator-selected");
 			if(!row.modules.select){
 				row.modules.select = {};
 			}
@@ -226,7 +227,6 @@ SelectRow.prototype._selectRow = function(rowInfo, silent, force){
 			if(row.modules.select.checkboxEl){
 				row.modules.select.checkboxEl.checked = true;
 			}
-			row.getElement().classList.add("tabulator-selected");
 
 			this.selectedRows.push(row);
 
@@ -292,6 +292,7 @@ SelectRow.prototype._deselectRow = function(rowInfo, silent){
 
 		if(index > -1){
 
+			row.getElement().classList.remove("tabulator-selected");
 			if(!row.modules.select){
 				row.modules.select = {};
 			}
@@ -300,7 +301,6 @@ SelectRow.prototype._deselectRow = function(rowInfo, silent){
 			if(row.modules.select.checkboxEl){
 				row.modules.select.checkboxEl.checked = false;
 			}
-			row.getElement().classList.remove("tabulator-selected");
 			self.selectedRows.splice(index, 1);
 
 			if(this.table.options.dataTreeSelectPropagate){


### PR DESCRIPTION
I believe this PR explains the issue better than raising an issue to explain the bug.

Anyway, see this [https://jsfiddle.net/rk9n6qc1/2/](https://jsfiddle.net/rk9n6qc1/2/)
1. Click on "select all" checkbox
2. Scroll to the last row
3. Click the checkbox on the last row
4. Error: Selection style not changed & no row selection event is fired

The cause seems to be rows that have not yet been fully created. In these cases, the row.getElement() eventually get into SelectRow.prototype.initializeRow where the row.modules.select values are overridden. 

I did the quick and easy thing of just moving the row.getElement call up a few rows. However, I suspect this issue may be solved cleaner by not overriding the modules.select inside initializeRow.
