### PR TITLE
Edits from null to "" were saving

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -517,11 +517,15 @@ Edit.prototype.editors = {
 		});
 
 		function onChange(e){
-			if(((cellValue === null || typeof cellValue === "undefined") && input.value !== "") || input.value !== cellValue){
-				if(success(input.value)){
-					cellValue = input.value; //persist value if successfully validated incase editor is used as header filter
+			if (input.value !== cellValue) {
+				if ((cellValue === null || typeof cellValue === "undefined") && input.value === "") {
+					cancel();
+				} else {
+					if (success(input.value)) {
+						cellValue = input.value; //persist value if successfully validated incase editor is used as header filter
+					}
 				}
-			}else{
+			} else {
 				cancel();
 			}
 		}


### PR DESCRIPTION
There is an issue with the if statement. It was allowing changes from null to "" to be saved even though the intension of ((cellValue === null || typeof cellValue === "undefined") && input.value !== "") (I assume) was to ignore them. They were being let through via input.value !== cellValue, because it is an "or" statement.