### PR TITLE
fix issue with fitToData() setting a column width for group columns

### DIFF
--- a/src/js/column.js
+++ b/src/js/column.js
@@ -1354,9 +1354,13 @@ Column.prototype.reinitializeWidth = function(force){
 	}
 };
 
-//set column width to maximum cell width
+//set column width to maximum cell width for non group columns
 Column.prototype.fitToData = function(){
 	var self = this;
+
+    if (self.isGroup){
+    	return;
+    }
 
 	if(!this.widthFixed){
 		this.element.style.width = "";


### PR DESCRIPTION
This should fix #3202

Problem was that `Column.prototype.fitToData` sets a fixed column width for column group headers, which yields to HTML like this:

```html
<div class="tabulator-col tabulator-col-group" role="columngroup" aria-sort="none" 
     aria-title="Dynamic golumn group" title="" style="width: 202px; height: 49px;">
  ...
</div>
```

where it should be like this:

```html
<div class="tabulator-col tabulator-col-group" role="columngroup" aria-sort="none" 
     aria-title="Static column group" title="" style="height: 49px;">
  ...
</div>
```

The fix corrects this behavior and doesn't set the `style="width: ...px;"` for column group headers.