### PR TITLE
added maxInitialWidth

### DIFF
--- a/src/js/column.js
+++ b/src/js/column.js
@@ -1357,7 +1357,7 @@ Column.prototype.reinitializeWidth = function(force){
 		this.table.modules.filter.hideHeaderFilterElements();
 	}
 
-	this.fitToData();
+	this.fitToData(force);
 
 	//show header filters again after layout is complete
 	if(this.table.modExists("filter")){
@@ -1366,7 +1366,7 @@ Column.prototype.reinitializeWidth = function(force){
 };
 
 //set column width to maximum cell width
-Column.prototype.fitToData = function(){
+Column.prototype.fitToData = function(force){
 	var self = this;
 
 	if(!this.widthFixed){
@@ -1389,7 +1389,7 @@ Column.prototype.fitToData = function(){
 
 		if(maxWidth){
 			var setTo = maxWidth + 1;
-			if (this.maxInitialWidth) {
+			if (this.maxInitialWidth && !force) {
 				setTo = Math.min(setTo, this.maxInitialWidth);
 			}
 			self.setWidthActual(setTo);

--- a/src/js/column.js
+++ b/src/js/column.js
@@ -227,7 +227,7 @@ var Column = function(def, parent){
 	this.width = null; //column width
 	this.widthStyled = ""; //column width prestyled to improve render efficiency
 	this.maxWidth = null; //column maximum width
-  this.maxInitialWidth = null;
+	this.maxInitialWidth = null;
 	this.maxWidthStyled = ""; //column maximum prestyled to improve render efficiency
 	this.minWidth = null; //column minimum width
 	this.minWidthStyled = ""; //column minimum prestyled to improve render efficiency
@@ -655,11 +655,11 @@ Column.prototype._buildColumnHeader = function(){
 		}
 	}
 
-  if(def.maxInitialWidth || this.table.options.columnMaxInitialWidth) {
-    if(def.maxInitialWidth !== false) {
-      this.maxInitialWidth = typeof def.maxInitialWidth == 'undefined' ? this.table.options.columnMaxInitialWidth : parseInt(def.maxInitialWidth);
-    }
-  }
+	if(def.maxInitialWidth || this.table.options.columnMaxInitialWidth) {
+		if(def.maxInitialWidth !== false) {
+			this.maxInitialWidth = typeof def.maxInitialWidth == 'undefined' ? this.table.options.columnMaxInitialWidth : parseInt(def.maxInitialWidth);
+		}
+	}
 
 	this.reinitializeWidth();
 
@@ -1342,18 +1342,16 @@ Column.prototype._prevVisibleColumn = function(index){
 
 Column.prototype.reinitializeWidth = function(force){
 	this.widthFixed = false;
-  console.log('Reinitializing Width')
-  console.log(this.width, this.maxInitialWidth)
 
 
 	//set width if present
 	if(typeof this.definition.width !== "undefined" && !force){
-    // maxInitialWidth ignored here as width specified
+		// maxInitialWidth ignored here as width specified
 		this.setWidth(this.definition.width);
 	}
 
-  // maxInitialWidth needs to bet set in fitToData.
-  
+	// maxInitialWidth needs to bet set in fitToData.
+
 	//hide header filters to prevent them altering column width
 	if(this.table.modExists("filter")){
 		this.table.modules.filter.hideHeaderFilterElements();
@@ -1390,7 +1388,7 @@ Column.prototype.fitToData = function(){
 		});
 
 		if(maxWidth){
-      var setTo = Math.min(maxWidth + 1, this.maxInitialWidth);
+			var setTo = Math.min(maxWidth + 1, this.maxInitialWidth);
 			self.setWidthActual(setTo);
 		}
 

--- a/src/js/column.js
+++ b/src/js/column.js
@@ -1388,7 +1388,10 @@ Column.prototype.fitToData = function(){
 		});
 
 		if(maxWidth){
-			var setTo = Math.min(maxWidth + 1, this.maxInitialWidth);
+			var setTo = maxWidth + 1;
+			if (this.maxInitialWidth) {
+				setTo = Math.min(setTo, this.maxInitialWidth);
+			}
 			self.setWidthActual(setTo);
 		}
 

--- a/src/js/column.js
+++ b/src/js/column.js
@@ -1154,10 +1154,6 @@ Column.prototype.setWidthActual = function(width){
 		width = Math.min(this.maxWidth, width);
 	}
 
-  if(this.maxInitialWidth) {
-    width = Math.min(this.maxInitialWidth, width)
-  }
-
 	this.width = width;
 	this.widthStyled = width ? width + "px" : "";
 
@@ -1352,6 +1348,9 @@ Column.prototype.reinitializeWidth = function(force){
 		this.setWidth(this.definition.width);
 	}
 
+  if (typeof this.maxInitialWidth !== 'undefined' && !force) {
+    this.setWidth(this.maxInitialWidth)
+  }
 	//hide header filters to prevent them altering column width
 	if(this.table.modExists("filter")){
 		this.table.modules.filter.hideHeaderFilterElements();

--- a/src/js/column.js
+++ b/src/js/column.js
@@ -227,6 +227,7 @@ var Column = function(def, parent){
 	this.width = null; //column width
 	this.widthStyled = ""; //column width prestyled to improve render efficiency
 	this.maxWidth = null; //column maximum width
+  this.maxInitialWidth = null;
 	this.maxWidthStyled = ""; //column maximum prestyled to improve render efficiency
 	this.minWidth = null; //column minimum width
 	this.minWidthStyled = ""; //column minimum prestyled to improve render efficiency
@@ -653,6 +654,12 @@ Column.prototype._buildColumnHeader = function(){
 			this.setMaxWidth(typeof def.maxWidth == "undefined" ? this.table.options.columnMaxWidth : parseInt(def.maxWidth));
 		}
 	}
+
+  if(def.maxInitialWidth || this.table.options.columnMaxInitialWidth) {
+    if(def.maxInitialWidth !== false) {
+      this.maxInitialWidth = typeof def.maxInitialWidth == 'undefined' ? this.table.options.columnMaxInitialWidth : parseInt(def.maxInitialWidth);
+    }
+  }
 
 	this.reinitializeWidth();
 
@@ -1147,6 +1154,10 @@ Column.prototype.setWidthActual = function(width){
 		width = Math.min(this.maxWidth, width);
 	}
 
+  if(this.maxInitialWidth) {
+    width = Math.min(this.maxInitialWidth, width)
+  }
+
 	this.width = width;
 	this.widthStyled = width ? width + "px" : "";
 
@@ -1442,6 +1453,7 @@ Column.prototype.defaultOptionList = [
 "width",
 "minWidth",
 "maxWidth",
+"maxInitialWidth",
 "widthGrow",
 "widthShrink",
 "resizable",

--- a/src/js/column.js
+++ b/src/js/column.js
@@ -1342,15 +1342,18 @@ Column.prototype._prevVisibleColumn = function(index){
 
 Column.prototype.reinitializeWidth = function(force){
 	this.widthFixed = false;
+  console.log('Reinitializing Width')
+  console.log(this.width, this.maxInitialWidth)
+
 
 	//set width if present
 	if(typeof this.definition.width !== "undefined" && !force){
+    // maxInitialWidth ignored here as width specified
 		this.setWidth(this.definition.width);
 	}
 
-  if (typeof this.maxInitialWidth !== 'undefined' && !force) {
-    this.setWidth(this.maxInitialWidth)
-  }
+  // maxInitialWidth needs to bet set in fitToData.
+  
 	//hide header filters to prevent them altering column width
 	if(this.table.modExists("filter")){
 		this.table.modules.filter.hideHeaderFilterElements();
@@ -1377,7 +1380,6 @@ Column.prototype.fitToData = function(){
 	}
 
 	var maxWidth = this.element.offsetWidth;
-
 	if(!self.width || !this.widthFixed){
 		self.cells.forEach(function(cell){
 			var width = cell.getWidth();
@@ -1388,7 +1390,8 @@ Column.prototype.fitToData = function(){
 		});
 
 		if(maxWidth){
-			self.setWidthActual(maxWidth + 1);
+      var setTo = Math.min(maxWidth + 1, this.maxInitialWidth);
+			self.setWidthActual(setTo);
 		}
 
 	}

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -47,7 +47,7 @@ Tabulator.prototype.defaultOptions = {
 
 	columnMinWidth:40, //minimum global width for a column
 	columnMaxWidth:false, //minimum global width for a column
-  columnMaxInitialWidth: false, // maximum width to be initially assigned (can grow bigger)
+	columnMaxInitialWidth: false, // maximum width to be initially assigned (can grow bigger)
 	columnHeaderVertAlign:"top", //vertical alignment of column headers
 	columnVertAlign:false, // DEPRECATED - Left to allow warning
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -47,6 +47,7 @@ Tabulator.prototype.defaultOptions = {
 
 	columnMinWidth:40, //minimum global width for a column
 	columnMaxWidth:false, //minimum global width for a column
+  columnMaxInitialWidth: false, // maximum width to be initially assigned (can grow bigger)
 	columnHeaderVertAlign:"top", //vertical alignment of column headers
 	columnVertAlign:false, // DEPRECATED - Left to allow warning
 


### PR DESCRIPTION
This is different from both `width` and `maxWidth` in that it simply limits the initial width of a column, it can still be resized larger afterwards, but initially it limits the width.

This is useful when you have a lot of columns of unknown sizes and you want to make things initially look pretty good

Still needs:
- Typings adding
- Website docs updating

I don't know how to do those