### PR TITLE
Filter value list based on active rows

### DIFF
--- a/src/js/modules/Edit/defaults/editors/autocomplete.js
+++ b/src/js/modules/Edit/defaults/editors/autocomplete.js
@@ -57,7 +57,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 
 	function getUniqueColumnValues(field){
 		var output = {},
-		data = self.table.getData(),
+		data = self.table.getData(editorParams.filterValuesList ? "active" : undefined),
 		column;
 
 		if(field){
@@ -98,6 +98,10 @@ export default function(cell, onRendered, success, cancel, editorParams){
 
 		//lookup base values list
 		if(uniqueColumnValues){
+			if(intialLoad !== true && term === "" && initialValue !== term && editorParams.filterValuesList === true){
+				success(term);
+				genUniqueColumnValues();
+			}
 			values = uniqueColumnValues;
 		}else{
 			values = editorParams.values || [];

--- a/src/js/modules/Edit/defaults/editors/select.js
+++ b/src/js/modules/Edit/defaults/editors/select.js
@@ -26,7 +26,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 
 	function getUniqueColumnValues(field){
 		var output = {},
-		data = self.table.getData(),
+		data = self.table.getData(editorParams.filterValuesList ? "active" : undefined),
 		column;
 
 		if(field){


### PR DESCRIPTION
This change adds 'filterValuesList' filter parameter. Setting this to true will limit the list of values to those that are already filtered. Common use case is multiple columns with header filters.

`headerFilterParams:{values:true,sortValuesList:"asc",filterValuesList:true}
`

The only quirk is that you have to may have to clear filters more frequently to get back to the full list of values, including the filter that was most recently updated.

Fiddle: https://jsfiddle.net/divinehawk/6vnq2wLm/
