### PR TITLE
Allow select editor to drop up

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -1263,6 +1263,17 @@ Edit.prototype.editors = {
 				});
 
 				document.body.appendChild(listEl);
+
+				if (editorParams.allowDropup === true) {
+					var totalHeight = listEl.offsetHeight + offset.top + cellEl.offsetHeight;
+
+					if (totalHeight > document.body.clientHeight) {
+						var offsetBottom = document.body.clientHeight - offset.top;
+	
+						listEl.style.top = "";
+						listEl.style.bottom = offsetBottom + "px";
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Right now the select editor will only drop down, even at the bottom of the document, which is not always the desired behavior.
This change adds a new optional property **allowDropup** available in **editorParams** object.
If the property is set to **true**, the editor will drop up if it's height is bigger than available space at the bottom of document.