### PR TITLE
fix issue with fitToData() setting a column width for group columns

### DIFF
--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -1084,8 +1084,12 @@ class Column {
 		}
 	}
 
-	//set column width to maximum cell width
+	//set column width to maximum cell width for non group columns
 	fitToData(){
+		if(this.isGroup){
+			return;
+		}
+		
 		if(!this.widthFixed){
 			this.element.style.width = "";
 


### PR DESCRIPTION
Updated pull request for https://github.com/olifolkerd/tabulator/pull/3203

Compatible with the 5.0 branch.