### PR TITLE
Fixing progress formatter to use relative container for absolute positioning of child legend and bar elements

### DIFF
--- a/src/js/modules/Format/defaults/formatters/progress.js
+++ b/src/js/modules/Format/defaults/formatters/progress.js
@@ -82,7 +82,7 @@ export default function(cell, formatterParams, onRendered){ //progress bar
 
 	var barEl = document.createElement("div");
 	barEl.style.display = "inline-block";
-	barEl.style.position = "relative";
+	barEl.style.position = "absolute";
 	barEl.style.width = percentValue + "%";
 	barEl.style.backgroundColor = color;
 	barEl.style.height = "100%";
@@ -90,11 +90,15 @@ export default function(cell, formatterParams, onRendered){ //progress bar
 	barEl.setAttribute('data-max', max);
 	barEl.setAttribute('data-min', min);
 
+	var barContainer = document.createElement("div");
+	barContainer.style.position = "relative";
+	barContainer.style.width = "100%";
+	barContainer.style.height = "100%";
 
 	if(legend){
 		var legendEl = document.createElement("div");
 		legendEl.style.position = "absolute";
-		legendEl.style.top = "4px";
+		legendEl.style.top = 0;
 		legendEl.style.left = 0;
 		legendEl.style.textAlign = legendAlign;
 		legendEl.style.width = "100%";
@@ -118,10 +122,11 @@ export default function(cell, formatterParams, onRendered){ //progress bar
 			element = holderEl;
 		}
 
-		element.appendChild(barEl);
+		element.appendChild(barContainer);
+		barContainer.appendChild(barEl);
 
 		if(legend){
-			element.appendChild(legendEl);
+			barContainer.appendChild(legendEl);
 		}
 	});
 


### PR DESCRIPTION
https://github.com/olifolkerd/tabulator/issues/3150

Changes to 5.0 looked like they were just separation of concerns and general file cleanup. I've made changes to the progress.js file to fix text vertical align issues, they are the same changes I made in my previous pull (see here https://github.com/olifolkerd/tabulator/pull/3151 ) request