### PR TITLE
Preserve vertical scroll position when adding a column to the table

### DIFF
--- a/src/js/column_manager.js
+++ b/src/js/column_manager.js
@@ -646,7 +646,7 @@ ColumnManager.prototype.addColumn = function(definition, before, nextToColumn){
 			this.table.modules.columnCalcs.recalc(this.table.rowManager.activeRows);
 		}
 
-		this.redraw(true);
+		this.redraw(true, true);
 
 		if(this.table.modules.layout.getMode() != "fitColumns"){
 			column.reinitializeWidth();
@@ -698,14 +698,16 @@ ColumnManager.prototype.deregisterColumn = function(column){
 };
 
 //redraw columns
-ColumnManager.prototype.redraw = function(force){
+ColumnManager.prototype.redraw = function(force, preserveScroll){
 	if(force){
 
 		if(Tabulator.prototype.helpers.elVisible(this.element)){
 			this._verticalAlignHeaders();
 		}
 
-		this.table.rowManager.resetScroll();
+		if(!preserveScroll){
+			this.table.rowManager.resetScroll();
+		}
 		this.table.rowManager.reinitialize();
 	}
 


### PR DESCRIPTION
Hi there,

It's totally possible that there are situations I'm unaware of where this would cause issues, but in my testing I didn't encounter any problems with preserving (i.e. not resetting) vertical scroll position when adding a column to the table. Would be great if you could take a look!

Thanks,
Yuji