### PR TITLE
Fix typo in Tabulator.js

### DIFF
--- a/src/js/core/Tabulator.js
+++ b/src/js/core/Tabulator.js
@@ -715,7 +715,7 @@ class Tabulator {
 
 		return this.columnManager.addColumn(definition, before, column)
 		.then((column) => {
-			returncolumn.getComponent();
+			return column.getComponent();
 		});
 	}
 


### PR DESCRIPTION
Just a missing space between 'return' and 'column'