### PR TITLE
Insert missing 'this' in VirtualDomHorizontal.js

### DIFF
--- a/src/js/core/rendering/renderers/VirtualDomHorizontal.js
+++ b/src/js/core/rendering/renderers/VirtualDomHorizontal.js
@@ -60,7 +60,7 @@ export default class VirtualDomHorizontal extends Renderer{
 		}
 
 		if(!ok){
-			options.virtualDomHoz = false;
+			this.options.virtualDomHoz = false;
 		}
 
 		return ok;


### PR DESCRIPTION
Just a missing 'this' before an object property