### PR TITLE
Fix incorrect render-virtual-fill subscription (and add missing 'var')

### DIFF
--- a/src/js/modules/GroupRows/GroupRows.js
+++ b/src/js/modules/GroupRows/GroupRows.js
@@ -147,7 +147,7 @@ class GroupRows extends Module{
 
 			this.subscribe("rows-sample", this.rowSample.bind(this));
 
-			this.subscribe("render-virtual-fill", this.rowAddingIndex.bind(this));
+			this.subscribe("render-virtual-fill", this.virtualRenderFill.bind(this));
 
 			this.registerDisplayHandler(this.getRows.bind(this), 20);
 
@@ -165,7 +165,7 @@ class GroupRows extends Module{
 
 	virtualRenderFill(){
 		var el = this.table.rowManager.tableElement;
-		rows = this.table.rowManager.getVisibleRows();
+		var rows = this.table.rowManager.getVisibleRows();
 
 		rows = rows.filter((row) => {
 			return row.type !== "group";


### PR DESCRIPTION
This was causing an error when using grouped rows because rowAddingIndex would be called without arguments; I think it's supposed to be virtualRenderFill instead?

Also, looks like a missing 'var' on what was meant to be a local variable.