### PR TITLE
Fix bug where GroupRows.displayIndex was not being set

### DIFF
--- a/src/js/modules/GroupRows/GroupRows.js
+++ b/src/js/modules/GroupRows/GroupRows.js
@@ -531,14 +531,14 @@ class GroupRows extends Module{
 			output = output.concat(group.getHeadersAndRows());
 		});
 
+		var displayIndex = this.table.rowManager.setDisplayRows(output, this.getDisplayIndex());
+
+		if(displayIndex !== true){
+			this.setDisplayIndex(displayIndex);
+		}
+
 		//force update of table display
 		if(force){
-			var displayIndex = this.table.rowManager.setDisplayRows(output, this.getDisplayIndex());
-
-			if(displayIndex !== true){
-				this.setDisplayIndex(displayIndex);
-			}
-
 			this.refreshData(true);
 		}
 


### PR DESCRIPTION
This fixes an issue where toggling group visibility would only work the first time after initializing a table, after which no groups could be toggled. Not 100% sure this is the right fix for this as I wasn't able to fully understand RowManager.setDisplayRows 