### PR TITLE
Fix issue #3328 - select headerFilter - freetext filtering change in behaviour between v4.7.0 and >=v4.7.1

### DIFF
--- a/src/js/modules/edit.js
+++ b/src/js/modules/edit.js
@@ -1398,7 +1398,7 @@ Edit.prototype.editors = {
 				break;
 
 				default:
-				if(self.currentCell === false){
+				if(self.currentCell === false && multiselect){
 					e.preventDefault();
 				}
 


### PR DESCRIPTION
As per #3328 

This re-enables text entry in edit.js if multiselect is not in use, by adding a conditional.