### PR TITLE
3340 Preserve vertical scroll position when adding a row to the table

### DIFF
--- a/src/js/core/tools/ModuleBinder.js
+++ b/src/js/core/tools/ModuleBinder.js
@@ -54,6 +54,17 @@ export default class ModuleBinder {
 			return Array.isArray(results) && !results.length ? false : results;
 		}
 
+		tabulator.prototype.getVerticalScroll = function () {
+			var rowHolder = this.rowManager.getElement();
+			var scrollTop = rowHolder.scrollTop;
+			return scrollTop;
+		};
+		
+		tabulator.prototype.setVerticalScroll = function (top) {
+			var rowHolder = this.rowManager.getElement();
+			rowHolder.scrollTop = top;
+		};
+
 		//ensure that module are bound to instantiated function
 		tabulator.prototype.bindModules = function(){
 			this.modules = {};


### PR DESCRIPTION
Added two methods for setting and setting the scroll position. This will be useful when the scroll position is set to 0 and you need to get the last position.