### PR TITLE
[fix] Add row in bottom position

### DIFF
--- a/src/js/row_manager.js
+++ b/src/js/row_manager.js
@@ -14,6 +14,7 @@ var RowManager = function(table){
 	this.rows = []; //hold row data objects
 	this.activeRows = []; //rows currently available to on display in the table
 	this.activeRowsCount = 0; //count of active rows
+	this.defaultPos = 
 
 	this.displayRows = []; //rows currently on display in the table
 	this.displayRowsCount = 0; //count of display rows
@@ -423,7 +424,7 @@ RowManager.prototype.deleteRow = function(row, blockRedraw){
 };
 
 RowManager.prototype.addRow = function(data, pos, index, blockRedraw){
-
+	if (!pos && this.table.options.addRowPos == "bottom") {pos = 0}
 	var row = this.addRowActual(data, pos, index, blockRedraw);
 
 	if(this.table.options.history && this.table.modExists("history")){


### PR DESCRIPTION
When I add this option: {addRowPos: "bottom"}, it is not added to the end of the table, it is always added to the beginning