### PR TITLE
Fix so caret and column label do not overlap

### DIFF
--- a/src/scss/tabulator.scss
+++ b/src/scss/tabulator.scss
@@ -1125,7 +1125,7 @@ $footerActiveColor:#d00 !default; //footer bottom active text color
 			}
 
 			.tabulator-col-content{
-				.tabulator-arrow{
+				.tabulator-col-sorter{
 					left:8px;
 					right:initial;
 				}


### PR DESCRIPTION
This is a fix I believe for the issue where a column label text and the sort caret overlap in RTL mode. Change the CSS class the aligns the caret to be `.tabulator-col-sorter` and not `.tabulator-arrow` with RTL styling.

#3498