### PR TITLE
Callback the cellEdited function on the definition if it exists

### DIFF
--- a/src/js/core/cell/Cell.js
+++ b/src/js/core/cell/Cell.js
@@ -191,6 +191,10 @@ export default class Cell extends CoreFeature{
 
 			this.cellRendered();
 
+			if(this.column.definition.cellEdited){
+				this.column.definition.cellEdited.call(this.table, this.getComponent());
+			}
+
 			this.dispatchExternal("cellEdited", this.getComponent());
 
 			if(this.subscribedExternal("dataChanged")){


### PR DESCRIPTION
As per the `cellEditing` and `cellEditCancelled` callbacks, the `cellEdited` callback should be fired before the corresponding event is dispatched.