### PR TITLE
5.0 max initial width and edit module resolution fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+insert_final_newline = true

--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -42,6 +42,7 @@ class Column extends CoreFeature{
 		this.widthStyled = ""; //column width prestyled to improve render efficiency
 		this.maxWidth = null; //column maximum width
 		this.maxWidthStyled = ""; //column maximum prestyled to improve render efficiency
+		this.maxInitialWidth = null;
 		this.minWidth = null; //column minimum width
 		this.minWidthStyled = ""; //column minimum prestyled to improve render efficiency
 		this.widthFixed = false; //user has specified a width for this column
@@ -320,6 +321,9 @@ class Column extends CoreFeature{
 		//set min width if present
 		this.setMinWidth(parseInt(def.minWidth));
 
+		if (def.maxInitialWidth || this.table.options.columnMaxInitialWidth) {
+			this.maxInitialWidth = typeof def.maxInitialWidth == 'undefined' ? parseInt(this.table.options.columnMaxInitialWidth) : parseInt(def.maxInitialWidth);
+		}
 		if(def.maxWidth){
 			this.setMaxWidth(parseInt(def.maxWidth));
 		}
@@ -928,18 +932,19 @@ class Column extends CoreFeature{
 
 		//set width if present
 		if(typeof this.definition.width !== "undefined" && !force){
+			// maxInitialWidth ignored here as width specified
 			this.setWidth(this.definition.width);
 		}
 
 		this.dispatch("column-width-fit-before", this);
 
-		this.fitToData();
+		this.fitToData(force);
 
 		this.dispatch("column-width-fit-after", this);
 	}
 
 	//set column width to maximum cell width for non group columns
-	fitToData(){
+	fitToData(force){
 		if(this.isGroup){
 			return;
 		}
@@ -964,7 +969,11 @@ class Column extends CoreFeature{
 			});
 
 			if(maxWidth){
-				this.setWidthActual(maxWidth + 1);
+				var setTo = maxWidth + 1;
+				if (this.maxInitialWidth && !force) {
+					setTo = Math.min(setTo, this.maxInitialWidth);
+				}
+				this.setWidthActual(setTo);
 			}
 		}
 	}

--- a/src/js/core/column/defaults/options.js
+++ b/src/js/core/column/defaults/options.js
@@ -8,6 +8,7 @@ export default {
 	"width": undefined,
 	"minWidth": 40,
 	"maxWidth": undefined,
+	"maxInitialWidth": undefined,
 	"tooltip": undefined,
 	"cssClass": undefined,
 	"variableHeight": undefined,

--- a/src/js/core/defaults/options.js
+++ b/src/js/core/defaults/options.js
@@ -9,6 +9,7 @@ export default {
 	maxHeight:false, //maximum height of tabulator
 
 	columnMaxWidth:false, //minimum global width for a column
+	columnMaxInitialWidth: false, // maximum initial width on first render
 	columnHeaderVertAlign:"top", //vertical alignment of column headers
 
 	columns:[],//store for colum header info

--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -118,7 +118,7 @@ class Edit extends Module{
 	///////////////////////////////////
 	clearCellEdited(cells){
 		if(!cells){
-			cells = this.modules.edit.getEditedCells();
+			cells = this.table.modules.edit.getEditedCells();
 		}
 
 		if(!Array.isArray(cells)){
@@ -126,7 +126,7 @@ class Edit extends Module{
 		}
 
 		cells.forEach((cell) => {
-			this.modules.edit.clearEdited(cell._getSelf());
+			this.table.modules.edit.clearEdited(cell._getSelf());
 		});
 	}
 


### PR DESCRIPTION
Max Initial Width is similar to Max Width except that it only applies on first render, so it allows the user to make columns larger (up to the actual maxWidth).

5.0 replacement for #3215

Also fixes a bug with edit module resolution