### PR TITLE
Json downloader can use titleDownload

### DIFF
--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -30,6 +30,7 @@ class Column extends CoreFeature{
 		this.getFieldValue = "";
 		this.setFieldValue = "";
 
+    this.titleDownload = null;
 		this.titleFormatterRendered = false;
 
 		this.mapDefinitions();
@@ -570,6 +571,10 @@ class Column extends CoreFeature{
 	getField(){
 		return this.field;
 	}
+
+  getTitleDownload() {
+    return this.titleDownload;
+  }
 
 	//return the first column in a group
 	getFirstColumn(){

--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -30,7 +30,7 @@ class Column extends CoreFeature{
 		this.getFieldValue = "";
 		this.setFieldValue = "";
 
-    this.titleDownload = null;
+		this.titleDownload = null;
 		this.titleFormatterRendered = false;
 
 		this.mapDefinitions();
@@ -572,9 +572,9 @@ class Column extends CoreFeature{
 		return this.field;
 	}
 
-  getTitleDownload() {
-    return this.titleDownload;
-  }
+	getTitleDownload() {
+		return this.titleDownload;
+	}
 
 	//return the first column in a group
 	getFirstColumn(){

--- a/src/js/core/column/ColumnComponent.js
+++ b/src/js/core/column/ColumnComponent.js
@@ -27,9 +27,9 @@ export default class ColumnComponent {
 		return this._column.getField();
 	}
 
-  getTitleDownload() {
-    return this._column.getTitleDownload();
-  }
+	getTitleDownload() {
+		return this._column.getTitleDownload();
+	}
 
 	getCells(){
 		var cells = [];

--- a/src/js/core/column/ColumnComponent.js
+++ b/src/js/core/column/ColumnComponent.js
@@ -27,6 +27,10 @@ export default class ColumnComponent {
 		return this._column.getField();
 	}
 
+  getTitleDownload() {
+    return this._column.getTitleDownload();
+  }
+
 	getCells(){
 		var cells = [];
 

--- a/src/js/modules/Download/defaults/downloaders/json.js
+++ b/src/js/modules/Download/defaults/downloaders/json.js
@@ -19,7 +19,7 @@ export default function(list, options, setFileContents){
 			case "row":
 			row.columns.forEach((col) => {
 				if(col){
-					item[col.component.getField()] = col.value;
+					item[col.component.getTitleDownload() || col.component.getField()] = col.value;
 				}
 			});
 


### PR DESCRIPTION
This allows you to override the key in the json objects.

Why is this useful?

In many cases the fields are abstract, and a user friendly key needs to be substituted.

For example in Beekeeper Studio two columns in a table can have the same title, so I need a way to make fields unique, but also provide a title for the download.

Replaces #3236