### PR TITLE
remove console.log in clearEditor function

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -405,7 +405,7 @@ class Edit extends Module{
 
 		this.invalidEdit = false;
 
-		console.log("clear", cancel, cell, cell.validate)
+		// console.log("clear", cancel, cell, cell.validate)
 
 		if(cell){
 			this.currentCell = false;


### PR DESCRIPTION
Hi Oli, fan of your work.

This stray console.log() line in `src/js/modules/Edit/Edit.js`  has made it to all the dist files.

It shows up here: https://github.com/olifolkerd/tabulator/blob/master/dist/js/tabulator.js#L13675
alongwith other places. Also in the .min.js .

Result: If I make cells in a column editable:
```
var tabulator1 = new Tabulator("#tabl", {
  height: 400,
  columns: [
    { title: "a", field: "b", cellEdited:function(cell){ return;} }
  ]
}
```
.. then this shows up in the browser console everytime we click into an editable cell and then out of it.
```
clear true r {table: n, column: r, row: n, element: div.tabulator-cell.tabulator-editing, value: '', …} undefined
```

This PR hides it. I've edited just the source code - so you can include the dist/ in next release