### PR TITLE
Prevent style sheets from being removed by tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "style": "dist/css/tabulator.css",
   "main": "dist/js/tabulator.js",
   "module": "dist/js/tabulator_esm.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "scripts": {
     "build": "rollup -c build/rollup.js",
     "dev": "rollup -c build/rollup.js -w --environment TARGET:dev",


### PR DESCRIPTION
## Purpose
Prevent an issue where CSS styles were sometimes stripped out by webpack tree shaking. When performing production builds with optimizations, this caused the table to appear without styling. 

These optimizations are turned on (though often only for production mode) in some default Vue CLI or create-react-app configurations. 

## Details
Tabulator 5 was restructured to use ES6 modules, and its package.json includes a `sideEffects: false` declaration.

Some applications use a common piece of webpack magic to embed styles via `import 'filename.css'`. In production (but sometimes not development mode!), all such side-effect-only imports will be stripped out, because Tabulator declares itself to have no side effects.

See [active webpack issue discussion](https://github.com/webpack/webpack/issues/6571#issuecomment-425366992) for examples of other tools that have been surprised by this behavior. It is particularly annoying for projects that want to use new Tabulator features without upgrading their entire build tool. (since vue cli and create react app manage the webpack config internally)

The easiest fix is for tabulator.js to explicitly declare that CSS and SCSS files have side effects. (see [webpack docs](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)). Eg, this is used by [bootstrap-vue](https://github.com/bootstrap-vue/bootstrap-vue/pull/2271).

## Testing
A specific internal app of ours uses `vue-cli` to build a component that declares `import 'tabulator-tables/dist/css/tabulator_bootstrap4.css';`. 

(behavior seen for vue CLI 3 projects; not sure about vue CLI 4)

This was tested using `npm link` for a local copy, before and after this PR change.

Before side effects:
![Screen Shot 2022-01-17 at 11 33 43 PM](https://user-images.githubusercontent.com/2957073/149871591-ea2aa756-4ec3-417b-8feb-e143d5d61deb.png)

After:
![Screen Shot 2022-01-17 at 11 29 35 PM](https://user-images.githubusercontent.com/2957073/149871191-01702295-2cdb-4ffc-977d-e66ff458ffe0.png)


### Further notes
Our team really appreciates Tabulator! Since this has bitten several of our Vue.js projects recently, I've posted the initial PR for visibility.... but I recognize that the test case depends on specific webpack config details. If you'd like me to create a more elaborate test case for evaluation, please just ask and I can continue adding to this PR over the next few days.