### PR TITLE
cellEdited event now fires

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -402,6 +402,7 @@ class Edit extends Module{
 	clearEditor(cancel){
 		var cell = this.currentCell,
 		cellEl;
+		var component = this.currentCell.getComponent();
 
 		this.invalidEdit = false;
 
@@ -423,6 +424,12 @@ class Edit extends Module{
 			while(cellEl.firstChild) cellEl.removeChild(cellEl.firstChild);
 
 			cell.row.getElement().classList.remove("tabulator-row-editing");
+
+			if(cell.column.definition.cellEdited) {
+				cell.column.definition.cellEdited.call(this.table, component);
+			}
+
+			this.dispatchExternal("cellEdited", component);
 		}
 	}
 


### PR DESCRIPTION
The cellEdited event did not fire.

I have to admit, I did not really dig into the code and simply copy-pasted from another event, but it works for me now (TM).
I hope this is helpful and many thanks for such a great library!