### PR TITLE
Allowing empty string as thousand separator in money formatter.

### DIFF
--- a/src/js/modules/Format/defaults/formatters/money.js
+++ b/src/js/modules/Format/defaults/formatters/money.js
@@ -25,10 +25,12 @@ export default function(cell, formatterParams, onRendered){
 	integer = number[0];
 	decimal = number.length > 1 ? decimalSym + number[1] : "";
 
-	rgx = /(\d+)(\d{3})/;
+	if (formatterParams.thousand !== false) {
+		rgx = /(\d+)(\d{3})/;
 
-	while (rgx.test(integer)){
-		integer = integer.replace(rgx, "$1" + thousandSym + "$2");
+		while (rgx.test(integer)){
+			integer = integer.replace(rgx, "$1" + thousandSym + "$2");
+		}
 	}
 
 	return after ? sign + integer + decimal + symbol : sign + symbol + integer + decimal;


### PR DESCRIPTION
This is a feature request to be able to have an empty string as the thousand separator (`money` formatter).

At the moment, using `thousand: ""` in `formatterParams` is effectively ignored, since it falls back to the default separator (`,`).

This patch makes it possible not to use a thousand separator at all (i.e. use an empty string).