### PR TITLE
Move rows on row drag

### DIFF
--- a/src/js/modules/MoveRows/MoveRows.js
+++ b/src/js/modules/MoveRows/MoveRows.js
@@ -392,10 +392,45 @@ class MoveRows extends Module{
 	moveHoverTable(e){
 		var rowHolder = this.table.rowManager.getElement(),
 		scrollTop = rowHolder.scrollTop,
-		yPos = ((this.touchMove ? e.touches[0].pageY : e.pageY) - rowHolder.getBoundingClientRect().top) + scrollTop,
+		rowHolderTop = rowHolder.getBoundingClientRect().top,
+		yPos = ((this.touchMove ? e.touches[0].pageY : e.pageY) - rowHolderTop) + scrollTop,
 		scrollPos;
 
 		this.hoverElement.style.top = (yPos - this.startY) + "px";
+
+		var MINSPEED = 2;
+        var MAXSPEED = 5;
+        // rowHolder.scrollTop += 300;
+        // console.log(yPos);
+        // console.log(rowHolder.getBoundingClientRect().top);
+        // console.log(e.pageY);
+        // console.log(rowHolder.offsetHeight);
+        // console.log(scrollTop);
+
+        function convertRange(oldVal, oldMin, oldMax, newMin, newMax) {
+          var oldRange = (oldMax - oldMin);
+          var newRange = (newMax - newMin);
+          var newVal = (((oldVal - oldMin) * newRange) / oldRange) + newMin;
+          return newVal;
+        }
+
+        if (e.pageY > rowHolder.offsetHeight - (0.35 * rowHolder.offsetHeight)) {
+          // if (rowHolder.scrollTop < rowHolder.offsetHeight) {
+            var convertedRange = Math.round(convertRange(e.pageY, rowHolder.offsetHeight / 2, rowHolder.offsetHeight, MINSPEED, MAXSPEED));
+            var clampedRange = Math.max(MINSPEED, Math.min(convertedRange, MAXSPEED));
+          // }
+          rowHolder.scrollTop += clampedRange;
+          // rowHolder.scrollTop += 5;
+        }
+        if (e.pageY - rowHolderTop < (0.35 * rowHolder.offsetHeight)) {
+          // if (rowHolder.scrollTop < rowHolder.offsetHeight) {
+            
+          // }
+          var convertedRange = Math.round(convertRange(e.pageY, 0, rowHolder.offsetHeight / 2, 2, 6));
+          var clampedRange = Math.max(MINSPEED, Math.min(convertedRange, MAXSPEED));
+          // rowHolder.scrollTop -= 5;
+          rowHolder.scrollTop -= clampedRange;
+        }
 	}
 
 	moveHoverConnections(e){

--- a/src/js/modules/MoveRows/MoveRows.js
+++ b/src/js/modules/MoveRows/MoveRows.js
@@ -399,7 +399,7 @@ class MoveRows extends Module{
 		this.hoverElement.style.top = (yPos - this.startY) + "px";
 
 		var MINSPEED = 2;
-        var MAXSPEED = 5;
+		var MAXSPEED = 5;
 
         function convertRange(oldVal, oldMin, oldMax, newMin, newMax) {
           var oldRange = (oldMax - oldMin);
@@ -414,7 +414,7 @@ class MoveRows extends Module{
           rowHolder.scrollTop += clampedRange;
         }
         if (e.pageY - rowHolderTop < (0.35 * rowHolder.offsetHeight)) {
-          var convertedRange = Math.round(convertRange(e.pageY, 0, rowHolder.offsetHeight / 2, 2, 6));
+          var convertedRange = Math.round(convertRange(e.pageY, 0, rowHolder.offsetHeight / 2, MINSPEED, MAXSPEED));
           var clampedRange = Math.max(MINSPEED, Math.min(convertedRange, MAXSPEED));
           rowHolder.scrollTop -= clampedRange;
         }

--- a/src/js/modules/MoveRows/MoveRows.js
+++ b/src/js/modules/MoveRows/MoveRows.js
@@ -400,12 +400,6 @@ class MoveRows extends Module{
 
 		var MINSPEED = 2;
         var MAXSPEED = 5;
-        // rowHolder.scrollTop += 300;
-        // console.log(yPos);
-        // console.log(rowHolder.getBoundingClientRect().top);
-        // console.log(e.pageY);
-        // console.log(rowHolder.offsetHeight);
-        // console.log(scrollTop);
 
         function convertRange(oldVal, oldMin, oldMax, newMin, newMax) {
           var oldRange = (oldMax - oldMin);
@@ -415,20 +409,13 @@ class MoveRows extends Module{
         }
 
         if (e.pageY > rowHolder.offsetHeight - (0.35 * rowHolder.offsetHeight)) {
-          // if (rowHolder.scrollTop < rowHolder.offsetHeight) {
             var convertedRange = Math.round(convertRange(e.pageY, rowHolder.offsetHeight / 2, rowHolder.offsetHeight, MINSPEED, MAXSPEED));
             var clampedRange = Math.max(MINSPEED, Math.min(convertedRange, MAXSPEED));
-          // }
           rowHolder.scrollTop += clampedRange;
-          // rowHolder.scrollTop += 5;
         }
         if (e.pageY - rowHolderTop < (0.35 * rowHolder.offsetHeight)) {
-          // if (rowHolder.scrollTop < rowHolder.offsetHeight) {
-            
-          // }
           var convertedRange = Math.round(convertRange(e.pageY, 0, rowHolder.offsetHeight / 2, 2, 6));
           var clampedRange = Math.max(MINSPEED, Math.min(convertedRange, MAXSPEED));
-          // rowHolder.scrollTop -= 5;
           rowHolder.scrollTop -= clampedRange;
         }
 	}


### PR DESCRIPTION
What this PR does:
When a row is dragged, scroll to top or bottom i.e. enables a more interactive drag. This addresses https://github.com/olifolkerd/tabulator/issues/3249#issuecomment-1036623968

Some issues that remain after applying this PR: 
1. the placeholder element is only available when dragged over certain number of elements beyond which it doesn't move anymore. My guess - is this due to `renderVerticalBuffer`? I am not sure.
2. The scroll only happens when when moving the mouse, not when _holding_ it at the bottom position.
3. Need to test touch events

I need help with the issues mentioned above
I am happy to help further but also would like feedback as I may not have all the context. Currently this is showing the potential changes that are required to enable a more interactive row drag