### PR TITLE
Fixed Footer Placement

### DIFF
--- a/src/js/core/FooterManager.js
+++ b/src/js/core/FooterManager.js
@@ -44,7 +44,7 @@ export default class FooterManager extends CoreFeature{
 					this.containerElement.innerHTML = this.table.options.footerElement;
 				}else{
 					this.external = true;
-					this.element = document.querySelector(this.table.options.footerElement);
+					this.containerElement = document.querySelector(this.table.options.footerElement);
 				}
 				break;
 

--- a/src/js/modules/Filter/Filter.js
+++ b/src/js/modules/Filter/Filter.js
@@ -617,9 +617,14 @@ class Filter extends Module{
 
 		var filterFunc = false;
 
-		if(typeof filter.field == "function"){
-			filterFunc = function(data){
-				return filter.field(data, filter.type || {})// pass params to custom filter function
+	 if (typeof filter.field == "function") {
+			filterFunc = function filterFunc(data) {
+				try {
+					return Filter.filters[filter.type](filter.value, column.getFieldValue(data).replace(/<\/?("[^"]*"|'[^']*'|[^>])*(>|$)/g, "").trim(), data, filter.params || {});
+				} catch (error) {
+					console.warn("Filter Error - Column not found, ignoring: ", filter.type);
+					return false;
+				}
 			};
 		}else{
 

--- a/src/js/modules/Filter/Filter.js
+++ b/src/js/modules/Filter/Filter.js
@@ -617,14 +617,9 @@ class Filter extends Module{
 
 		var filterFunc = false;
 
-	 if (typeof filter.field == "function") {
-			filterFunc = function filterFunc(data) {
-				try {
-					return Filter.filters[filter.type](filter.value, column.getFieldValue(data).replace(/<\/?("[^"]*"|'[^']*'|[^>])*(>|$)/g, "").trim(), data, filter.params || {});
-				} catch (error) {
-					console.warn("Filter Error - Column not found, ignoring: ", filter.type);
-					return false;
-				}
+		if(typeof filter.field == "function"){
+			filterFunc = function(data){
+				return filter.field(data, filter.type || {})// pass params to custom filter function
 			};
 		}else{
 


### PR DESCRIPTION
What does this PR:

After version 5.1 the footer didn't work anymore this was partly fixed in version 5.1.3 but you stil not able to place the footer in your own div, therefore I created this PR in order to fix this issue.

You can now do the following:
![image](https://user-images.githubusercontent.com/77294984/156176627-1a61f3be-34e8-4d08-87cf-5236648a60c3.png)

Before it would have looked like this:
![image](https://user-images.githubusercontent.com/77294984/156178070-828b1698-31c8-4ec6-9874-76e2d32cc92d.png)

You can see that on the second image that the pagination is within the tabulator (grey div). You might need the open the images in a second tab because it is not realy clear on the screenshots.










