### PR TITLE
Dismiss menus when editing a cell

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -638,8 +638,8 @@ class Edit extends Module{
 					cell.column.definition.cellEditing.call(this.table, component);
 				}
 
-				this.dispatchExternal("cellEditing", component);
 				this.dispatch("cell-editing", cell);
+				this.dispatchExternal("cellEditing", component);
 
 				params = typeof cell.column.modules.edit.params === "function" ? cell.column.modules.edit.params(component) : cell.column.modules.edit.params;
 

--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -639,6 +639,7 @@ class Edit extends Module{
 				}
 
 				this.dispatchExternal("cellEditing", component);
+				this.dispatch("cell-editing", cell)
 
 				params = typeof cell.column.modules.edit.params === "function" ? cell.column.modules.edit.params(component) : cell.column.modules.edit.params;
 

--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -639,7 +639,7 @@ class Edit extends Module{
 				}
 
 				this.dispatchExternal("cellEditing", component);
-				this.dispatch("cell-editing", cell)
+				this.dispatch("cell-editing", cell);
 
 				params = typeof cell.column.modules.edit.params === "function" ? cell.column.modules.edit.params(component) : cell.column.modules.edit.params;
 

--- a/src/js/modules/Menu/Menu.js
+++ b/src/js/modules/Menu/Menu.js
@@ -313,6 +313,7 @@ class Menu extends Module{
 		
 		setTimeout(() => {
 			this.table.rowManager.element.addEventListener("scroll", this.blurEvent);
+			this.table.on('cellEditing', this.blurEvent)
 			document.body.addEventListener("click", this.blurEvent);
 			document.body.addEventListener("contextmenu", this.blurEvent);
 			window.addEventListener("resize", this.blurEvent);
@@ -366,6 +367,7 @@ class Menu extends Module{
 		document.body.removeEventListener("contextmenu", this.blurEvent);
 		window.removeEventListener("resize", this.blurEvent);
 		this.table.rowManager.element.removeEventListener("scroll", this.blurEvent);
+		this.table.off('cellEdited', this.blurEvent)
 		
 		if(this.currentComponent){
 			this.dispatchExternal("menuClosed", this.currentComponent.getComponent());

--- a/src/js/modules/Menu/Menu.js
+++ b/src/js/modules/Menu/Menu.js
@@ -313,7 +313,7 @@ class Menu extends Module{
 		
 		setTimeout(() => {
 			this.table.rowManager.element.addEventListener("scroll", this.blurEvent);
-			this.table.on("cellEditing", this.blurEvent);
+			this.subscribe("cell-editing", this.blurEvent);
 			document.body.addEventListener("click", this.blurEvent);
 			document.body.addEventListener("contextmenu", this.blurEvent);
 			window.addEventListener("resize", this.blurEvent);
@@ -367,7 +367,7 @@ class Menu extends Module{
 		document.body.removeEventListener("contextmenu", this.blurEvent);
 		window.removeEventListener("resize", this.blurEvent);
 		this.table.rowManager.element.removeEventListener("scroll", this.blurEvent);
-		this.table.off("cellEdited", this.blurEvent);
+		this.unsubscribe("cell-editing", this.blurEvent);
 		
 		if(this.currentComponent){
 			this.dispatchExternal("menuClosed", this.currentComponent.getComponent());

--- a/src/js/modules/Menu/Menu.js
+++ b/src/js/modules/Menu/Menu.js
@@ -313,7 +313,7 @@ class Menu extends Module{
 		
 		setTimeout(() => {
 			this.table.rowManager.element.addEventListener("scroll", this.blurEvent);
-			this.table.on('cellEditing', this.blurEvent)
+			this.table.on("cellEditing", this.blurEvent);
 			document.body.addEventListener("click", this.blurEvent);
 			document.body.addEventListener("contextmenu", this.blurEvent);
 			window.addEventListener("resize", this.blurEvent);
@@ -367,7 +367,7 @@ class Menu extends Module{
 		document.body.removeEventListener("contextmenu", this.blurEvent);
 		window.removeEventListener("resize", this.blurEvent);
 		this.table.rowManager.element.removeEventListener("scroll", this.blurEvent);
-		this.table.off('cellEdited', this.blurEvent)
+		this.table.off("cellEdited", this.blurEvent);
 		
 		if(this.currentComponent){
 			this.dispatchExternal("menuClosed", this.currentComponent.getComponent());


### PR DESCRIPTION
Current behavior:
- Make a menu appear
- Click a cell to edit
- Menu stays open < we don't want this

New behavior:
- Make a menu appear
- Click a cell to edit
- Menu closes < we DO want this

## Before Video

https://user-images.githubusercontent.com/279769/157895280-2c032c08-f385-4ac6-8471-9173fa8e2143.mp4



## After Video

https://user-images.githubusercontent.com/279769/157895290-708a5bf6-3da5-4b31-bdc8-2bc2fe42564d.mp4


