### PR TITLE
VueJS3 Fix `TypeError: this.bindings[type][name].bind is not a function`

### DIFF
--- a/src/js/core/tools/ComponentFunctionBinder.js
+++ b/src/js/core/tools/ComponentFunctionBinder.js
@@ -12,14 +12,14 @@ export default class ComponentFunctionBinder{
 		}
 
 		if(this.bindings[type][funcName]){
-			console.warn("Unable to bind component handler, a matching function name is already bound", type, funcName, hanlder)
+			console.warn("Unable to bind component handler, a matching function name is already bound", type, funcName, handler)
 		}else{
 			this.bindings[type][funcName] = handler;
 		}
 	}
 
 	handle(type, component, name){
-		if(this.bindings[type] && this.bindings[type][name]){
+		if(this.bindings[type] && this.bindings[type][name] && typeof this.bindings[type][name].bind === 'function'){
 			return this.bindings[type][name].bind(null, component);
 		}else{
 			if(name !== "then" && typeof name === "string" && !name.startsWith("_")){


### PR DESCRIPTION
Hi. I ran into an error while using the latest version of tabulator (5.1.7) + vue js (3.2.31) + webpack (5.70.0)

Here my custom component, looks almost like on docs:
```
<template>
    <div ref="table"></div>
</template>

<script>
import { TabulatorFull as Tabulator } from 'tabulator-tables';

export default {
    name: 'Tabulator',

    props: {
        tableData: Array,
        columns:   Array,
    },

    data() {
        return {
            tableInstance: null, // variable to hold your table
        }
    },

    mounted() {
        // instantiate Tabulator when element is mounted
        this.tableInstance = new Tabulator(this.$refs.table, {
            data:         [], // link data to table
            reactiveData: true, // enable data reactivity
            columns:      this.columns, // define table columns
        });
    },

    watch: {
        // update table if data changes
        tableData: {
            handler(newData) {
                this.tableInstance.replaceData(newData);
            },
            deep: true,
        }
    },
}
</script>

<style scoped></style>
```

And that error occures after updating tableData from parent component
![image](https://user-images.githubusercontent.com/16826622/158101407-c7b8b1b1-0e4f-42d0-b96d-b1e31037a173.png)


Changes from PR resolves my issue.


PS: i didnt rebuild that package (just src updates), because of breaking project lines separators.
PS2: sorry if i violated the PR creating rules=)