### PR TITLE
Issue #3671 -  Revert Back to first page on changing filter or sorting

### DIFF
--- a/src/js/modules/Edit/defaults/editors/select.js
+++ b/src/js/modules/Edit/defaults/editors/select.js
@@ -480,6 +480,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		if(!input.value){
 			unsetItems();
 			chooseItems();
+			showList();
 		}
 	});
 

--- a/src/js/modules/Filter/Filter.js
+++ b/src/js/modules/Filter/Filter.js
@@ -553,7 +553,7 @@ class Filter extends Module{
 			if(this.table.options.filterMode === "remote"){
 				this.reloadData();
 			}else{
-				this.refreshData(true);
+				this.refreshData();
 			}
 		}
 

--- a/src/js/modules/Sort/Sort.js
+++ b/src/js/modules/Sort/Sort.js
@@ -206,7 +206,7 @@ class Sort extends Module{
 		if(this.table.options.sortMode === "remote"){
 			this.reloadData();
 		}else{
-			this.refreshData(true);
+			this.refreshData();
 		}
 
 		//TODO - Persist left position of row manager


### PR DESCRIPTION
As per previous release  `this.refreshData()` must pass without `true` param