### PR TITLE
Clearing select filter doesn't load select list

### DIFF
--- a/src/js/modules/Edit/defaults/editors/select.js
+++ b/src/js/modules/Edit/defaults/editors/select.js
@@ -480,6 +480,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		if(!input.value){
 			unsetItems();
 			chooseItems();
+			showList();
 		}
 	});
 


### PR DESCRIPTION
@olifolkerd 

If we clear `select` filter, options are not listing. We have to focus again to repopulate the list 

Based on [Stackoverflow](https://stackoverflow.com/questions/71616899/react-tabulator-header-filter-for-specific-select-column-remove-x/71625650#71625650)

You can verify [JSFiddle](https://jsfiddle.net/doublehrajput/zertj4Lo/)

My workaround of this solution [CodeSandbox](https://codesandbox.io/s/xenodochial-spence-ly2xdd)

As per me you have to update

```
input.addEventListener("search", function(e){
	if(!input.value){
		unsetItems();
		chooseItems();
		showList();  // show list when value is blacnk
	}
});
```

