### PR TITLE
For formatter and sorter, accept datetimes that are already Luxon DateTime objects (vs. strings)

### DIFF
--- a/src/js/modules/Format/defaults/formatters/datetime.js
+++ b/src/js/modules/Format/defaults/formatters/datetime.js
@@ -6,7 +6,15 @@ export default function(cell, formatterParams, onRendered){
 	var value = cell.getValue();
 
 	if(typeof DT != "undefined"){
-		var newDatetime = DT.isDateTime(value) ? value : ( inputFormat === "iso" ? DT.fromISO(String(value)) : DT.fromFormat(String(value), inputFormat) );
+		var newDatetime;
+
+		if(DT.isDateTime(value)){
+			 newDatetime = value;
+		 }else if(inputFormat === "iso"){
+			 newDatetime = DT.fromISO(String(value));
+		 }else{
+			 newDatetime = DT.fromFormat(String(value), inputFormat);
+		 }
 
 		if(newDatetime.isValid){
 			if(formatterParams.timezone){

--- a/src/js/modules/Format/defaults/formatters/datetime.js
+++ b/src/js/modules/Format/defaults/formatters/datetime.js
@@ -6,7 +6,7 @@ export default function(cell, formatterParams, onRendered){
 	var value = cell.getValue();
 
 	if(typeof DT != "undefined"){
-		var newDatetime = inputFormat === "iso" ? DT.fromISO(String(value)) : DT.fromFormat(String(value), inputFormat);
+		var newDatetime = DT.isDateTime(value) ? value : ( inputFormat === "iso" ? DT.fromISO(String(value)) : DT.fromFormat(String(value), inputFormat) );
 
 		if(newDatetime.isValid){
 			if(formatterParams.timezone){

--- a/src/js/modules/Format/defaults/formatters/datetimediff.js
+++ b/src/js/modules/Format/defaults/formatters/datetimediff.js
@@ -9,8 +9,15 @@ export default function (cell, formatterParams, onRendered) {
 	var value = cell.getValue();
 
 	if(typeof DT != "undefined"){
+		var newDatetime;
 
-		var newDatetime = DT.isDateTime(value) ? value : ( inputFormat === "iso" ? DT.fromISO(String(value)) : DT.fromFormat(String(value), inputFormat) );
+		if(DT.isDateTime(value)){
+			 newDatetime = value;
+		 }else if(inputFormat === "iso"){
+			 newDatetime = DT.fromISO(String(value));
+		 }else{
+			 newDatetime = DT.fromFormat(String(value), inputFormat);
+		 }
 
 		if (newDatetime.isValid){
 			if(humanize){

--- a/src/js/modules/Format/defaults/formatters/datetimediff.js
+++ b/src/js/modules/Format/defaults/formatters/datetimediff.js
@@ -9,8 +9,8 @@ export default function (cell, formatterParams, onRendered) {
 	var value = cell.getValue();
 
 	if(typeof DT != "undefined"){
-		
-		var newDatetime = inputFormat === "iso" ? DT.fromISO(String(value)) : DT.fromFormat(String(value), inputFormat);
+
+		var newDatetime = DT.isDateTime(value) ? value : ( inputFormat === "iso" ? DT.fromISO(String(value)) : DT.fromFormat(String(value), inputFormat) );
 
 		if (newDatetime.isValid){
 			if(humanize){

--- a/src/js/modules/Sort/defaults/sorters/datetime.js
+++ b/src/js/modules/Sort/defaults/sorters/datetime.js
@@ -6,8 +6,21 @@ export default function(a, b, aRow, bRow, column, dir, params){
 	emptyAlign = 0;
 
 	if(typeof DT != "undefined"){
-		a = DT.isDateTime(a) ? a : ( format === "iso" ? DT.fromISO(String(a)) : DT.fromFormat(String(a), format) );
-		b = DT.isDateTime(a) ? b : ( format === "iso" ? DT.fromISO(String(b)) : DT.fromFormat(String(b), format) );
+		if(DT.isDateTime(a)){
+			 a = a;
+		}else if(inputFormat === "iso"){
+			 a = DT.fromISO(String(a));
+		}else{
+			 a = DT.fromFormat(String(a), inputFormat);
+		}
+
+		if(DT.isDateTime(b)){
+			 b = b;
+		}else if(inputFormat === "iso"){
+			 a = DT.fromISO(String(b));
+		}else{
+			 b = DT.fromFormat(String(b), inputFormat);
+		}
 
 		if(!a.isValid){
 			emptyAlign = !b.isValid ? 0 : -1;

--- a/src/js/modules/Sort/defaults/sorters/datetime.js
+++ b/src/js/modules/Sort/defaults/sorters/datetime.js
@@ -6,8 +6,8 @@ export default function(a, b, aRow, bRow, column, dir, params){
 	emptyAlign = 0;
 
 	if(typeof DT != "undefined"){
-		a = format === "iso" ? DT.fromISO(String(a)) : DT.fromFormat(String(a), format);
-		b = format === "iso" ? DT.fromISO(String(b)) : DT.fromFormat(String(b), format);
+		a = DT.isDateTime(a) ? a : ( format === "iso" ? DT.fromISO(String(a)) : DT.fromFormat(String(a), format) );
+		b = DT.isDateTime(a) ? b : ( format === "iso" ? DT.fromISO(String(b)) : DT.fromFormat(String(b), format) );
 
 		if(!a.isValid){
 			emptyAlign = !b.isValid ? 0 : -1;


### PR DESCRIPTION
Currently, the built-in formatter and sorter are "unaware" when datetime data is Luxon DataTime objects,  Instead, to use the built-in formatter and/or sorter, the data must 1) be converted to a string which is then 2) re-converted back into a DataTime object and, finally, 3) converted once again to a string.

This change allows use of DateTime objects directly bypassing steps 1 & 2.  It does introduce a low-cost check to determine if the data is a DataTime object.