### PR TITLE
Fix data validation logic in v5

### DIFF
--- a/src/js/modules/Validate/Validate.js
+++ b/src/js/modules/Validate/Validate.js
@@ -89,7 +89,7 @@ class Validate extends Module{
 		var invalid = [];
 		
 		column.cells.forEach((cell) => {
-			if(!this.cellValidate(cell)){
+			if(this.cellValidate(cell) !== true){
 				invalid.push(cell.getComponent());
 			}
 		});
@@ -105,7 +105,7 @@ class Validate extends Module{
 		var invalid = [];
 		
 		row.cells.forEach((cell) => {
-			if(!this.cellValidate(cell)){
+			if(this.cellValidate(cell) !== true){
 				invalid.push(cell.getComponent());
 			}
 		});


### PR DESCRIPTION
Before 5.0, the `Cell#validate` method would return a boolean (`true` if valid, `false` if invalid).

Since 5.0, cell, row, and column validation [has been moved](https://github.com/olifolkerd/tabulator/commit/f622cf1e16d3452486b4013a68aaf7e3890216a8) to the Validate module.

The `Validate#cellValidate` method returns `true` if the cell is valid and an array of failed validators if the cell is invalid.

Unfortunately, the `Validate#columnValidate` and `Validate#rowValidate` methods still expect `Validate#cellValidate` to return either a _truthy_ value if valid and a _falsy_ value if invalid.

This pull request corrects the inconsistent logic.

This resolves #3206 and potentially other issues.