### PR TITLE
fix multiselect

### DIFF
--- a/src/js/modules/Edit/List.js
+++ b/src/js/modules/Edit/List.js
@@ -73,7 +73,7 @@ export default class Edit{
         this.initialValues = initialValue;
 
         if(this.isFilter){
-            this.input.value = this.initialValues ? this.initialValues.join(",") : [];
+            this.input.value = this.initialValues.join(",");
             this.headerFilterInitialListGen();
         }
     }

--- a/src/js/modules/Edit/List.js
+++ b/src/js/modules/Edit/List.js
@@ -62,19 +62,16 @@ export default class Edit{
     
     _initializeValue(){
         var initialValue = this.cell.getValue();
-
-        if(initialValue === "" && typeof this.params.defaultValue !== "undefined"){
+        
+        if(typeof initialValue === "undefined" && typeof this.params.defaultValue !== "undefined"){
             initialValue = this.params.defaultValue;
         }
-
-        if(typeof initialValue === "string"){
-            initialValue = [initialValue];
-        }
-        this.initialValues = initialValue;
-
+        
+        this.input.value = this.params.multiselect ? this.initialValues : this.initialValues.join(",");
+        
         if(this.isFilter){
             this.input.value = this.initialValues.join(",");
-            this.headerFilterInitialListGen();
+            this.headerFilterInitialListGen();            
         }
     }
     

--- a/src/js/modules/Edit/List.js
+++ b/src/js/modules/Edit/List.js
@@ -62,16 +62,19 @@ export default class Edit{
     
     _initializeValue(){
         var initialValue = this.cell.getValue();
-        
-        if(typeof initialValue === "undefined" && typeof this.params.defaultValue !== "undefined"){
+
+        if(initialValue === "" && typeof this.params.defaultValue !== "undefined"){
             initialValue = this.params.defaultValue;
         }
-        
-        this.initialValues = this.params.multiselect ? initialValue : [initialValue];
-        
+
+        if(typeof initialValue === "string"){
+            initialValue = [initialValue];
+        }
+        this.initialValues = initialValue;
+
         if(this.isFilter){
-            this.input.value = this.initialValues.join(",");
-            this.headerFilterInitialListGen();            
+            this.input.value = this.initialValues ? this.initialValues.join(",") : [];
+            this.headerFilterInitialListGen();
         }
     }
     


### PR DESCRIPTION
getValue never returns an undefined value, therefore we check for an empty string instead. Since we need to join in all cases (not only for multiselect = true), if the initialValue is a string, we convert it to an array. As a safety measure, don't join if there is no initialValues (shouldn't be necessary but that never hurts)