### PR TITLE
fix null warnings

### DIFF
--- a/src/js/core/cell/Cell.js
+++ b/src/js/core/cell/Cell.js
@@ -118,7 +118,6 @@ export default class Cell extends CoreFeature{
 			}
 			break;
 			case "undefined":
-			case "null":
 			this.element.innerHTML = "";
 			break;
 			default:

--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -377,7 +377,6 @@ class Column extends CoreFeature{
 			}
 			break;
 			case "undefined":
-			case "null":
 			el.innerHTML = "";
 			break;
 			default:

--- a/src/js/modules/Download/defaults/downloaders/csv.js
+++ b/src/js/modules/Download/defaults/downloaders/csv.js
@@ -30,7 +30,7 @@ export default function(list, options, setFileContents){
 
 					switch(typeof col.value){
 						case "object":
-						col.value = col.value ? JSON.stringify(col.value) : "";
+						col.value = col.value !== null ? JSON.stringify(col.value) : "";
 						break;
 
 						case "undefined":

--- a/src/js/modules/Download/defaults/downloaders/csv.js
+++ b/src/js/modules/Download/defaults/downloaders/csv.js
@@ -30,11 +30,10 @@ export default function(list, options, setFileContents){
 
 					switch(typeof col.value){
 						case "object":
-						col.value = JSON.stringify(col.value);
+						col.value = col.value ? JSON.stringify(col.value) : "";
 						break;
 
 						case "undefined":
-						case "null":
 						col.value = "";
 						break;
 					}

--- a/src/js/modules/Download/defaults/downloaders/pdf.js
+++ b/src/js/modules/Download/defaults/downloaders/pdf.js
@@ -57,7 +57,7 @@ export default function(list, options, setFileContents){
 			if(col){
 				switch(typeof col.value){
 					case "object":
-					col.value = col.value ? JSON.stringify(col.value) : "";
+					col.value = col.value !== null ? JSON.stringify(col.value) : "";
 					break;
 
 					case "undefined":

--- a/src/js/modules/Download/defaults/downloaders/pdf.js
+++ b/src/js/modules/Download/defaults/downloaders/pdf.js
@@ -57,11 +57,10 @@ export default function(list, options, setFileContents){
 			if(col){
 				switch(typeof col.value){
 					case "object":
-					col.value = JSON.stringify(col.value);
+					col.value = col.value ? JSON.stringify(col.value) : "";
 					break;
 
 					case "undefined":
-					case "null":
 					col.value = "";
 					break;
 				}

--- a/src/js/modules/Export/Export.js
+++ b/src/js/modules/Export/Export.js
@@ -510,11 +510,10 @@ class Export extends Module{
 				}else{
 					switch(typeof value){
 						case "object":
-						value = JSON.stringify(value);
+						value = value ? JSON.stringify(value) : "";
 						break;
 
 						case "undefined":
-						case "null":
 						value = "";
 						break;
 

--- a/src/js/modules/Export/Export.js
+++ b/src/js/modules/Export/Export.js
@@ -510,7 +510,7 @@ class Export extends Module{
 				}else{
 					switch(typeof value){
 						case "object":
-						value = value ? JSON.stringify(value) : "";
+						value = value !== null ? JSON.stringify(value) : "";
 						break;
 
 						case "undefined":

--- a/src/js/modules/Page/Page.js
+++ b/src/js/modules/Page/Page.js
@@ -609,7 +609,6 @@ class Page extends Module{
 				}
 				break;
 				case "undefined":
-				case "null":
 				this.pageCounterElement.innerHTML = "";
 				break;
 				default:


### PR DESCRIPTION
typeof never returns "null"
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null

while it's not a big issue (it's never going to match, and it's handled in the "object" case), it's better to keep the code clean
i caught this while trying to compile the source with esbuild

other option is to do something like var check = value === null ? "null" : typeof value;