### PR TITLE
add extra tabulator-table-editing class

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -411,6 +411,7 @@ class Edit extends Module{
 			while(cellEl.firstChild) cellEl.removeChild(cellEl.firstChild);
 
 			cell.row.getElement().classList.remove("tabulator-row-editing");
+			cell.table.element.classList.remove("tabulator-table-editing");
 		}
 	}
 
@@ -633,6 +634,7 @@ class Edit extends Module{
 					if(cellEditor instanceof Node){
 						element.classList.add("tabulator-editing");
 						cell.row.getElement().classList.add("tabulator-row-editing");
+						cell.table.element.classList.add("tabulator-table-editing");
 						while(element.firstChild) element.removeChild(element.firstChild);
 						element.appendChild(cellEditor);
 


### PR DESCRIPTION
this allows to handle some complex scenarios where you would want for instance to:
- show editable cells on hover
- but remove the hover effect if you moved to another row through keyboard nav

Example css to leverage this:

```css
.tabulator:not(.tabulator-table-editing)
    .tabulator-row:hover
    .tabulator-cell-editable,
.tabulator.tabulator-table-editing
    .tabulator-row-editing
    .tabulator-cell-editable {
    background: var(--tabulator-highlight-color);
}
```