### PR TITLE
properly deal with null and undefined

### DIFF
--- a/src/js/modules/Edit/defaults/editors/input.js
+++ b/src/js/modules/Edit/defaults/editors/input.js
@@ -6,6 +6,10 @@ export default function(cell, onRendered, success, cancel, editorParams){
 	var cellValue = cell.getValue(),
 	input = document.createElement("input");
 
+	if((cellValue === null || typeof cellValue === "undefined")) {
+		cellValue = "";
+	}
+
 	input.setAttribute("type", editorParams.search ? "search" : "text");
 
 	input.style.padding = "4px";
@@ -23,7 +27,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 
-	input.value = typeof cellValue !== "undefined" ? cellValue : "";
+	input.value = cellValue;
 
 	onRendered(function(){
 		input.focus({preventScroll: true});
@@ -35,7 +39,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 	});
 
 	function onChange(e){
-		if(((cellValue === null || typeof cellValue === "undefined") && input.value !== "") || input.value !== cellValue){
+		if(input.value !== cellValue){
 			if(success(input.value)){
 				cellValue = input.value; //persist value if successfully validated incase editor is used as header filter
 			}


### PR DESCRIPTION
the current condition does not work as intended because of the || clause that use strict !== (null or undefined is always !== than input.value)

(cellValue === null || typeof cellValue === "undefined") && input.value !== "") || input.value !== cellValue

if cellValue is null, when entering the input then leaving it, it will mark the field as "edited" when in fact there was nothing done (there is no way to distinguish "null/undefined" from blank "" in the input field). Therefore, clicking the first time creates an "edited" callback, and next time, and "cancelled" callback.

this PR fixes this by treating null, undefined and "" as "" by default.

another enhancement would be to add a editorParam to allow "null" as a text value that should be converted to actual "null" value. This could be useful for header filters that should match actual "null" db values for example, but that's outside the scope of this PR.