### PR TITLE
consistent value for elementField

### DIFF
--- a/src/js/modules/DataTree/DataTree.js
+++ b/src/js/modules/DataTree/DataTree.js
@@ -143,7 +143,7 @@ class DataTree extends Module{
 	initializeElementField(){
 		var firstCol = this.table.columnManager.getFirstVisibleColumn();
 
-		this.elementField = this.table.options.dataTreeElementColumn || (firstCol ? firstCol.field : false);
+		this.elementField = this.table.options.dataTreeElementColumn || (firstCol && firstCol.field ? firstCol.field : false);
 	}
 	
 	getRowChildren(row){


### PR DESCRIPTION
since firstCol can exist but firstCol.field can be undefined, it's better to check for firstCol.field also and ensure elementField is either "false" or is a string (better than false, undefined or string)

in my opinion, elementField should rather start at "null" rather then false since it's a nullable string, and I'm happy to make the change if needed ;-)