### PR TITLE
Update progress.js to introduce hozAlign: "right" as formatter param

### DIFF
--- a/src/js/modules/Format/defaults/formatters/progress.js
+++ b/src/js/modules/Format/defaults/formatters/progress.js
@@ -86,6 +86,9 @@ export default function(cell, formatterParams = {}, onRendered){ //progress bar
 	barEl.style.width = percentValue + "%";
 	barEl.style.backgroundColor = color;
 	barEl.style.height = "100%";
+	if (formatterParams.hozAlign === "right") {
+	  barEl.style.right = "0";
+	}
 
 	barEl.setAttribute('data-max', max);
 	barEl.setAttribute('data-min', min);


### PR DESCRIPTION
hozAlign: "right" as option for the progress bar formatter params.