### PR TITLE
update min width if set on table element

### DIFF
--- a/src/js/modules/Layout/defaults/modes/fitColumns.js
+++ b/src/js/modules/Layout/defaults/modes/fitColumns.js
@@ -101,6 +101,11 @@ export default function(columns){
 		totalWidth -= this.table.rowManager.element.offsetWidth - this.table.rowManager.element.clientWidth;
 	}
 
+	// Update min width on tableholder if set
+	if(this.table.rowManager.tableElement.style.minWidth) {
+		this.table.rowManager.tableElement.style.minWidth = totalWidth + "px";
+	}
+
 	columns.forEach(function(column){
 		var width, minWidth, colWidth;
 


### PR DESCRIPTION
when there is a min width set by renderEmptyScroll, that min width may not take into account the scrollbars. Therefore, it will cause a horizontal scrollbar when rendering actual data causing the table to overflow.
adjusting the min width avoid this effect

i didn't manage yet to make a codepen to show this, but these lines effectively fix the issue in my project and i don't think they should have any side effect (if no min width is set, it doesn nothing, so it applies only if renderEmptyScroll was called in the first place)