### PR TITLE
Adding `options` to ColumnComponent#setWidth

### DIFF
--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -644,20 +644,23 @@ class Column extends CoreFeature{
 		}
 	}
 
-	setWidth(width){
+	setWidth(width, options){
 		this.widthFixed = true;
-		this.setWidthActual(width);
+		this.setWidthActual(width, options || {});
 	}
 
-	setWidthActual(width){
+	setWidthActual(width, options){
+
+    const maxWidth = options.maxWidth || this.maxWidth;
+    const minWidth = options.minWidth || this.minWidth;
 		if(isNaN(width)){
 			width = Math.floor((this.table.element.clientWidth/100) * parseInt(width));
 		}
 
-		width = Math.max(this.minWidth, width);
+		width = Math.max(minWidth, width);
 
-		if(this.maxWidth){
-			width = Math.min(this.maxWidth, width);
+		if(maxWidth){
+			width = Math.min(maxWidth, width);
 		}
 
 		this.width = width;


### PR DESCRIPTION
This adds the ability to override max and min width when calling setWidth.

## Why?

When setting the width of a column it is helpful to have sensible limits, but we might not want to set hard `min` and `max` values for the columns to allow users to resize them manually.

For example, when calling `setWidth(true)` to fit column width to content size we might want to provide a `max` to stop things getting out of hand, but also don't want to fully restrict the user's ability to make the column bigger manually.

## Usage

```js
// resize to fit contents, up to 500px wide max
column.setWidth(true, { maxWidth: 500 });
```
