### PR TITLE
Bug Fix: navPrev will not shift focus to the row above

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -157,7 +157,7 @@ class Edit extends Module{
 				prevRow = this.table.rowManager.prevDisplayRow(cell.row, true);
 				
 				if(prevRow){
-					nextCell = this.findNextEditableCell(prevRow, prevRow.cells.length);
+					nextCell = this.findPrevEditableCell(prevRow, prevRow.cells.length);
 					
 					if(nextCell){
 						nextCell.getComponent().edit();


### PR DESCRIPTION
The `navPrev` keybinding descriptions is...   
`Shift focus to the next editable cell on the left, if none available move to the right most editable cell on the row above` http://tabulator.info/docs/5.3/keybindings#overview

Shift focus to the next editable cell to the left works, but the focus will not shift to the row above. The fix was to simply call `findPrevEditableCell()` instead of `findNextEditableCell()`.

Demonstration of the bug: https://jsfiddle.net/6czv0xs3/
The `Favorite Color` column is configured as `editable: "input"`. Tab works to select the color on the next row. However, shift-tab does not work to select the color on the previous row.