### PR TITLE
fix isVisible() of GroupComponent

### DIFF
--- a/src/js/modules/GroupRows/GroupComponent.js
+++ b/src/js/modules/GroupRows/GroupComponent.js
@@ -40,7 +40,8 @@ class GroupComponent {
 	}
 
 	isVisible(){
-		return this._group._visible;
+		this._group._visSet();
+		return this._group.visible;
 	}
 
 	show(){


### PR DESCRIPTION
Fix for #3963.

I found calling `_group._visSet()` to be necessary, as `group.visible` may be a function initially (until `_visSet()` is called).