### PR TITLE
Use consistent method of determining table width for different layouts

### DIFF
--- a/src/js/modules/Layout/defaults/modes/fitColumns.js
+++ b/src/js/modules/Layout/defaults/modes/fitColumns.js
@@ -1,6 +1,6 @@
 //resize columns to fit
 export default function(columns, forced){
-	var totalWidth = this.table.rowManager.element.getBoundingClientRect().width; //table element width
+	var totalWidth = this.table.rowManager.element.clientWidth; //table element width
 	var fixedWidth = 0; //total width of columns with a defined width
 	var flexWidth = 0; //total width available to flexible columns
 	var flexGrowUnits = 0; //total number of widthGrow blocks across all columns


### PR DESCRIPTION
The "fitColumns" layout uses getBoundingClientRect() which can lead to unstable results in some cases.

Both "fitDataStrech" and "fitDataFill" use this.table.rowManager.element.clientWidth so it's reasonable to use it in "fitColumns" for consistency.