### PR TITLE
check existence of cells before generating new

### DIFF
--- a/src/js/core/row/Row.js
+++ b/src/js/core/row/Row.js
@@ -315,7 +315,7 @@ export default class Row extends CoreFeature{
 		
 		column = this.table.columnManager.findColumn(column);
 		
-		if(!this.initialized){
+		if(!this.initialized && this.cells.length === 0){
 			this.generateCells();
 		}
 		
@@ -339,7 +339,7 @@ export default class Row extends CoreFeature{
 	}
 	
 	getCells(){
-		if(!this.initialized){
+		if(!this.initialized && this.cells.length === 0){
 			this.generateCells();
 		}
 		


### PR DESCRIPTION
If `updateData` is repeatedly called on not yet initialized rows new cells are always being generated causing memory leaks.
Fixes #4056.