### PR TITLE
Fix data for "row-added" event dispatch

### DIFF
--- a/src/js/core/RowManager.js
+++ b/src/js/core/RowManager.js
@@ -331,7 +331,7 @@ export default class RowManager extends CoreFeature{
 			data.forEach((item, i) => {
 				var row = this.addRow(item, pos, index, true);
 				rows.push(row);
-				this.dispatch("row-added", row, data, pos, index);
+				this.dispatch("row-added", row, item, pos, index);
 			});
 
 			this.refreshActiveData(refreshDisplayOnly ? "displayPipeline" : false, false, true);


### PR DESCRIPTION
"row-added" is dispatched for each row, so it shouldn't send the array of data for all the rows being added. This change fixes the history's "rowAdd" action so the redoer can successfully recreate the row. Without this fix, the redoer creates a blank row since the _rowAdded_ function at [History.js:40](https://github.com/olifolkerd/tabulator/blob/fad536be0a5ce6822622582e4fa536cd8f88cdf4/src/js/modules/History/History.js) assumes _data_ contains a single row when it's actually an array.

This change doesn't affect any other functionality since the _data_ parameter isn't used by any other subscribers:
- [FrozenRows.js:46](https://github.com/olifolkerd/tabulator/blob/master/src/js/modules/FrozenRows/FrozenRows.js) only uses _row_
- [ColumnCalc.js:123](https://github.com/olifolkerd/tabulator/blob/master/src/js/modules/ColumnCalcs/ColumnCalcs.js) only uses _row_
- [Page.js:227](https://github.com/olifolkerd/tabulator/blob/master/src/js/modules/Page/Page.js) doesn't reference anything

[JSFiddle before fix](https://jsfiddle.net/q2pv0twe/)
[JSFiddle after fix](https://jsfiddle.net/7knc289s/)