### PR TITLE
Fix date/time editors

### DIFF
--- a/src/js/modules/Edit/defaults/editors/date.js
+++ b/src/js/modules/Edit/defaults/editors/date.js
@@ -66,7 +66,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	});
 	
-	function onChange(e){
+	function onChange(){
 		var value = input.value;
 		
 		if(((cellValue === null || typeof cellValue === "undefined") && value !== "") || value !== cellValue){
@@ -86,7 +86,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 	//submit new value on blur
 	input.addEventListener("blur", function(e) {
 		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
-			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+			onChange(); // only on a "true" blur; not when focusing browser's date/time picker
 		}
 	});
 	
@@ -95,7 +95,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		switch(e.keyCode){
 			// case 9:
 			case 13:
-				onChange(e);
+				onChange();
 				break;
 			
 			case 27:

--- a/src/js/modules/Edit/defaults/editors/date.js
+++ b/src/js/modules/Edit/defaults/editors/date.js
@@ -83,9 +83,12 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 	
-	//submit new value on blur or change
-	input.addEventListener("change", onChange);
-	input.addEventListener("blur", onChange);
+	//submit new value on blur
+	input.addEventListener("blur", function(e) {
+		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
+			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+		}
+	});
 	
 	//submit new value on enter
 	input.addEventListener("keydown", function(e){

--- a/src/js/modules/Edit/defaults/editors/datetime.js
+++ b/src/js/modules/Edit/defaults/editors/datetime.js
@@ -53,7 +53,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	});
 	
-	function onChange(e){
+	function onChange(){
 		var value = input.value;
 
 		if(((cellValue === null || typeof cellValue === "undefined") && value !== "") || value !== cellValue){
@@ -73,7 +73,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 	//submit new value on blur
 	input.addEventListener("blur", function(e) {
 		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
-			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+			onChange(); // only on a "true" blur; not when focusing browser's date/time picker
 		}
 	});
 	
@@ -82,7 +82,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		switch(e.keyCode){
 			// case 9:
 			case 13:
-				onChange(e);
+				onChange();
 				break;
 			
 			case 27:

--- a/src/js/modules/Edit/defaults/editors/datetime.js
+++ b/src/js/modules/Edit/defaults/editors/datetime.js
@@ -70,9 +70,12 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 	
-	//submit new value on blur or change
-	input.addEventListener("change", onChange);
-	input.addEventListener("blur", onChange);
+	//submit new value on blur
+	input.addEventListener("blur", function(e) {
+		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
+			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+		}
+	});
 	
 	//submit new value on enter
 	input.addEventListener("keydown", function(e){

--- a/src/js/modules/Edit/defaults/editors/time.js
+++ b/src/js/modules/Edit/defaults/editors/time.js
@@ -54,7 +54,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	});
 	
-	function onChange(e){
+	function onChange(){
 		var value = input.value;
 
 		if(((cellValue === null || typeof cellValue === "undefined") && value !== "") || value !== cellValue){
@@ -74,7 +74,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 	//submit new value on blur
 	input.addEventListener("blur", function(e) {
 		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
-			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+			onChange(); // only on a "true" blur; not when focusing browser's date/time picker
 		}
 	});
 	
@@ -83,7 +83,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		switch(e.keyCode){
 			// case 9:
 			case 13:
-				onChange(e);
+				onChange();
 				break;
 			
 			case 27:

--- a/src/js/modules/Edit/defaults/editors/time.js
+++ b/src/js/modules/Edit/defaults/editors/time.js
@@ -71,9 +71,12 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 	
-	//submit new value on blur or change
-	input.addEventListener("change", onChange);
-	input.addEventListener("blur", onChange);
+	//submit new value on blur
+	input.addEventListener("blur", function(e) {
+		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
+			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+		}
+	});
 	
 	//submit new value on enter
 	input.addEventListener("keydown", function(e){


### PR DESCRIPTION
With date, datetime, and time inputs, the "change" event fires with nearly every key press (whenever there's a valid entry), so the editors are calling _onChange(e)_ before the desired value can be typed fully. I removed the "change" event listeners so the changes are only processed upon "blur" or enter key. I also added logic to ignore the premature "blur" event when opening FireFox's built-in date/time picker. Tested this solution in Edge, Chrome, FireFox, and Safari. This fixes Issues #4019 and #4102.

[JSFiddle before fix](https://jsfiddle.net/3q4hso1p/)

[JSFiddle after fix](https://jsfiddle.net/m0sv5dxk/)