### PR TITLE
Header Filter Persistence support

### DIFF
--- a/src/js/modules/Persistence/Persistence.js
+++ b/src/js/modules/Persistence/Persistence.js
@@ -88,6 +88,7 @@ class Persistence extends Module{
 			this.config = {
 				sort:this.table.options.persistence === true || this.table.options.persistence.sort,
 				filter:this.table.options.persistence === true || this.table.options.persistence.filter,
+				headerFilter:this.table.options.persistence === true || this.table.options.persistence.headerFilter,
 				group:this.table.options.persistence === true || this.table.options.persistence.group,
 				page:this.table.options.persistence === true || this.table.options.persistence.page,
 				columns:this.table.options.persistence === true ? ["title", "width", "visible"] : this.table.options.persistence.columns,
@@ -138,6 +139,7 @@ class Persistence extends Module{
 			this.subscribe("table-redraw", this.tableRedraw.bind(this));
 
 			this.subscribe("filter-changed", this.eventSave.bind(this, "filter"));
+			this.subscribe("filter-changed", this.eventSave.bind(this, "headerFilter"));
 			this.subscribe("sort-changed", this.eventSave.bind(this, "sort"));
 			this.subscribe("group-changed", this.eventSave.bind(this, "group"));
 			this.subscribe("page-changed", this.eventSave.bind(this, "page"));
@@ -157,7 +159,7 @@ class Persistence extends Module{
 	}
 
 	tableBuilt(){
-		var sorters, filters;
+		var sorters, filters, headerFilters;
 
 		if(this.config.sort){
 			sorters = this.load("sort");
@@ -174,6 +176,14 @@ class Persistence extends Module{
 				this.table.options.initialFilter = filters;
 			}
 		}
+		if(this.config.headerFilter){
+			headerFilters = this.load("headerFilter");
+
+			if(!headerFilters === false){
+				this.table.options.initialHeaderFilter = headerFilters;
+			}
+		}
+		
 	}
 
 	tableRedraw(force){
@@ -332,6 +342,10 @@ class Persistence extends Module{
 
 			case "filter":
 				data = this.table.modules.filter.getFilters();
+				break;
+
+			case "headerFilter":
+				data = this.table.modules.filter.getHeaderFilters();
 				break;
 
 			case "sort":


### PR DESCRIPTION
I added the support for saving the Header Filter to the persistence mode, as requested in the https://github.com/olifolkerd/tabulator/issues/4091 issue.

I need it for one of my projects and looking throught the Persistence module adding this feature seems to me pretty straigthforward.

I added an option to the Persistence configuration 
```
persistence: {
  headerFilter: true
}
```
It has no options, like the `filter` configuration can be active or disabled.