### PR TITLE
Sanitize keywords string

### DIFF
--- a/src/js/modules/Filter/defaults/filters.js
+++ b/src/js/modules/Filter/defaults/filters.js
@@ -55,7 +55,11 @@ export default {
 
 	//contains the keywords
 	"keywords":function(filterVal, rowVal, rowData, filterParams){
-		var keywords = filterVal.toLowerCase().split(typeof filterParams.separator === "undefined" ? " " : filterParams.separator),
+		var keywords = filterVal.toLowerCase()
+			.replace(/\s+/g, ' ')
+			.trimEnd()
+			.trimStart()
+			.split(typeof filterParams.separator === "undefined" ? " " : filterParams.separator),
 		value = String(rowVal === null || typeof rowVal === "undefined" ? "" : rowVal).toLowerCase(),
 		matches = [];
 


### PR DESCRIPTION
Today if we filter using "Keywords", if we have spaces at the beginning, the end or extra spaces in the middle of a string, the search breaks.

I created this to sanitize the string from extra spaces to keep the essential.