### PR TITLE
Fixing De-Selection after selecting all rows

### DIFF
--- a/src/js/modules/SelectRow/SelectRow.js
+++ b/src/js/modules/SelectRow/SelectRow.js
@@ -354,7 +354,7 @@ class SelectRow extends Module{
 		
 		if(row){
 			index = self.selectedRows.findIndex(function(selectedRow){
-				return selectedRow == row;
+				return selectedRow.position == row.position;
 			});
 			
 			if(index > -1){


### PR DESCRIPTION
Depending of the source of calling `_deselectRow` the selectedRow in this comparison could be a either a Row or a Row encapsulated into a Proxy (`Proxy(Row)`). You can reproduce this behavior as followed:

### Scenario 1 (working)

1. Select a certain row
2. Deselect that row

Here it will compare `Proxy(Row)` with `Proxy(Row)` and it would behave as expected.

 ### Scenario 2 (not working)

1. Use the Select All feature of the table header, for selecting all rows
2. Deselect one of the Rows from the table

Now it will compare `Row` with `Proxy(Row)` and therefor the the comparison will fail. This is leading to the next code block is completely ignored, the deselection is not applied and the deselection event is not fired.

Although It would be better to find the source for the different contents of `selectedRows` this can be a possible quick fix to avoid that bug.