### PR TITLE
fix initial height and width measurements on table draw

### DIFF
--- a/src/js/core/RowManager.js
+++ b/src/js/core/RowManager.js
@@ -1035,7 +1035,7 @@ export default class RowManager extends CoreFeature{
 		let resized = false;
 		
 		if(this.renderer.verticalFillMode === "fill"){
-			let otherHeight =  Math.floor(this.table.columnManager.getElement().getBoundingClientRect().height + (this.table.footerManager && this.table.footerManager.active && !this.table.footerManager.external ? this.table.footerManager.getElement().getBoundingClientRect().height : 0));
+			let otherHeight =  this.table.columnManager.getElement().offsetHeight + (this.table.footerManager && this.table.footerManager.active && !this.table.footerManager.external ? this.table.footerManager.getElement().offsetHeight : 0);
 			
 			if(this.fixedHeight){
 				minHeight = isNaN(this.table.options.minHeight) ? this.table.options.minHeight : this.table.options.minHeight + "px";

--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -732,7 +732,7 @@ class Column extends CoreFeature{
 	}
 
 	getHeight(){
-		return Math.ceil(this.element.getBoundingClientRect().height);
+		return this.element.offsetHeight;
 	}
 
 	setMinWidth(minWidth){

--- a/src/js/modules/Layout/defaults/modes/fitColumns.js
+++ b/src/js/modules/Layout/defaults/modes/fitColumns.js
@@ -1,6 +1,6 @@
 //resize columns to fit
 export default function(columns, forced){
-	var totalWidth = this.table.rowManager.element.getBoundingClientRect().width; //table element width
+	var totalWidth = this.table.rowManager.element.offsetWidth; //table element width
 	var fixedWidth = 0; //total width of columns with a defined width
 	var flexWidth = 0; //total width available to flexible columns
 	var flexGrowUnits = 0; //total number of widthGrow blocks across all columns


### PR DESCRIPTION
Fix for https://github.com/olifolkerd/tabulator/issues/4364. 
When calculating the table size, we should use the layout with and height, not the rendered width and height.