### PR TITLE
fix broken columns when there are a fixed column and a hidden column

### DIFF
--- a/src/js/modules/FrozenColumns/FrozenColumns.js
+++ b/src/js/modules/FrozenColumns/FrozenColumns.js
@@ -34,6 +34,7 @@ class FrozenColumns extends Module{
 		this.subscribe("column-deleted", this.reinitializeColumns.bind(this));
 		this.subscribe("column-hide", this.reinitializeColumns.bind(this));
 		this.subscribe("column-show", this.reinitializeColumns.bind(this));
+		this.subscribe("columns-loaded", this.reinitializeColumns.bind(this));
 		
 		this.subscribe("table-redraw", this.layout.bind(this));
 		this.subscribe("layout-refreshing", this.blockLayout.bind(this));


### PR DESCRIPTION
![image](https://github.com/olifolkerd/tabulator/assets/38707148/0dce7549-62d2-4ab2-8601-23e32cfb522a)

Here's the link to reproduce the bug: https://jsfiddle.net/azmy60/c2fwzgtk/3/

For a context, in beekeeper, we have a table that have a frozen column (for spreadsheet row header) and a hidden column (for [index column](https://tabulator.info/docs/5.6/data#row-index)).

This happens if we have a combination of virtual horizontal renderer enabled, a frozen column and a hidden column. Disabling one of them would fix the bug.

After looking through the internal of tabulator, I found that the new `column-hide` event in `FrozenColumn` tries to initialize frozen columns **before** the columns are loaded by the `Tabulator` class, which makes the `leftColumns` and other states of the module reset to an empty array.

Tested this against #4400 as well.