### PR TITLE
Add missing column resize & move events

### DIFF
--- a/src/js/modules/MoveColumns/MoveColumns.js
+++ b/src/js/modules/MoveColumns/MoveColumns.js
@@ -201,6 +201,7 @@ class MoveColumns extends Module{
 		}
 		
 		this.moveHover(e);
+		this.table.externalEvents.dispatch("columnMoveStart", column);
 	}
 	
 	_bindMouseMove(){

--- a/src/js/modules/ResizeColumns/ResizeColumns.js
+++ b/src/js/modules/ResizeColumns/ResizeColumns.js
@@ -149,6 +149,7 @@ class ResizeColumns extends Module{
 				self.startColumn = column;
 				self.initialNextColumn = self.nextColumn = nearestColumn.nextColumn();
 				self._mouseDown(e, nearestColumn, handle);
+				self.table.externalEvents.dispatch("columnResizeStart", nearestColumn.getComponent());
 			};
 			
 			handle.addEventListener("mousedown", handleDown);
@@ -259,6 +260,8 @@ class ResizeColumns extends Module{
 			if(!self.table.browserSlow && column.modules.resize && column.modules.resize.variableHeight){
 				column.checkCellHeights();
 			}
+
+			self.table.externalEvents.dispatch("columnResizeMoved", column.getComponent());
 		}
 		
 		function mouseUp(e){


### PR DESCRIPTION
Adds two events: `columnResizeStart`, `columnResizeMoved` and `columnMoveStart`. The need for them is explained in #4403.
I'm open to renaming the events to meet the conventions used elsewhere in the project.

With the added events we were able to integrate https://sa-si-dev.github.io/virtual-select in the header columns.