### PR TITLE
fix broken range UI when using SelectRange and virtual horizontal renderer

### DIFF
--- a/src/js/modules/SelectRange/Range.js
+++ b/src/js/modules/SelectRange/Range.js
@@ -165,6 +165,10 @@ class Range extends CoreFeature{
 		_vDomLeft = this.table.columnManager.renderer.leftCol,
 		_vDomRight = this.table.columnManager.renderer.rightCol,		
 		top, bottom, left, right, topLeftCell, bottomRightCell;
+
+		if(this.rangeManager.rowHeader) {
+			_vDomRight += 1;
+		}
 		
 		if (_vDomTop == null) {
 			_vDomTop = 0;

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -50,6 +50,14 @@ class SelectRange extends Module {
 			}else{
 				console.warn("SelectRange functionality cannot be used in conjunction with row selection");
 			}
+
+			if(this.options('columns').findIndex((column) => column.frozen) > 0) {
+				console.warn("Having frozen column in arbitrary position with selectRange option may result in unpredictable behavior.");
+			}
+
+			if(this.options('columns').filter((column) => column.frozen) > 1) {
+				console.warn("Having multiple frozen columns with selectRange option may result in unpredictable behavior.");
+			}
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes the issue of range element that doesn't cover all selected cells if all columns are selected. This happens if we have a frozen column (row header) and the virtual horizontal renderer is enabled. In this image, I selected all columns but notice that the range lines don't cover the `internal` column.

![image](https://github.com/olifolkerd/tabulator/assets/38707148/42185225-d138-4e4f-9c57-6b7f32901c6b)

Demo: https://jsfiddle.net/fo97hyrk/

Also, I added some warnings for folks to be cautious to use frozen columns along with `SelectRange`. For now, I think it's best to have a frozen column just for row header.