### PR TITLE
Fix bug of getRowFromPosition function when groupComponent exists.

### DIFF
--- a/src/js/core/RowManager.js
+++ b/src/js/core/RowManager.js
@@ -194,7 +194,7 @@ export default class RowManager extends CoreFeature{
 	
 	getRowFromPosition(position){
 		return this.getDisplayRows().find((row) => {
-			return row.getPosition() === position && row.isDisplayed();
+			return row.type === "row" && row.getPosition() === position && row.isDisplayed();
 		});
 	}
 	


### PR DESCRIPTION
Fix the bug of `getRowFromPosition` function in `RowManager`
When the result returned in `getDisplayRows ()` contains `GroupComponent`, an error will be reported.
![image](https://github.com/olifolkerd/tabulator/assets/55378864/7c23280d-7c73-4f9c-b64b-9e1e0afa0f5d)
