### PR TITLE
fix selectRange and clipboard bug

### DIFF
--- a/src/js/modules/SelectRange/Range.js
+++ b/src/js/modules/SelectRange/Range.js
@@ -152,7 +152,7 @@ class Range extends CoreFeature{
 	}
 	
 	_getTableRows() {
-		return this.table.rowManager.getDisplayRows();
+		return this.table.rowManager.getDisplayRows().filter(row=> row.type === "row");
 	}
 	
 	///////////////////////////////////

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -808,7 +808,7 @@ class SelectRange extends Module {
 	}
 	
 	getTableRows() {
-		return this.table.rowManager.getDisplayRows();
+		return this.table.rowManager.getDisplayRows().filter(row=> row.type === "row");
 	}
 	
 	getTableColumns() {


### PR DESCRIPTION
## Please deal with this `bug`#4414 before dealing with it.  Demo cannot be provided because `bug`#4414 exists.
## Bug description
``` javascript
this.table = new TabulatorFull("#container", {
			groupBy: "group",
			layout: "fitColumns",
			selectableRange: 1,
			selectableRangeColumns: false,
			selectableRangeRows: false,
			selectableRangeClearCells: true,
			editTriggerEvent: "dblclick",
			clipboard: true,
			clipboardCopyStyled: false,
			clipboardCopyConfig: {
				columnHeaders: false,
			},
			clipboardCopyRowRange: "range",
			clipboardPasteParser: "range",
			clipboardPasteAction: "range",
			columnDefaults: {
				headerSort: false,
				editor: "input",
				editable: true,
			},
			data: [
				{
					group: "GroupFoo",
					A: "A1",
					B: "B1",
					row: 1,
				},
				{
					group: "GroupFoo",
					A: "A2",
					B: "B2",
					row: 2,
				},
				{
					group: "GroupFoo",
					row: 3,
				},
				{
					group: "GroupFoo",
					row: 4,
				},
			],
			columns: [
				{
					field: "row",
					width: 10,
				},
				{
					title: "A",
					field: "A",
				},
				{
					title: "B",
					field: "B",
				},
			],
		});
```
When we use "selectableRange" and "clipboard", the following problems will occur.
![image](https://github.com/olifolkerd/tabulator/assets/55378864/511f1e98-a6f8-44bd-b371-12413120269b)
+ As shown in the figure，When we copy the value of `A2` to `A3`, we will actually change the value of `A2` into the value of `A1`.
+ When "A4" is selected, and then the keys of "shift" and "down" are pressed, it is out of the range of the array and an error is reported.
![image](https://github.com/olifolkerd/tabulator/assets/55378864/1e279a44-3d09-4fc6-9d31-c18c17b3aecd)

The above two bugs are caused by "groupComponent" not being filtered.
