### PR TITLE
Fix incorrectly calculated height on collapes rows

### DIFF
--- a/src/js/modules/ResponsiveLayout/ResponsiveLayout.js
+++ b/src/js/modules/ResponsiveLayout/ResponsiveLayout.js
@@ -249,6 +249,7 @@ class ResponsiveLayout extends Module{
 			if(contents){
 				el.appendChild(contents);
 			}
+			row.calcHeight(true);
 		}
 	}
 


### PR DESCRIPTION
Hey Oli, 

as mentioned in the issue #3654 ( So i'm going to copy and paste a bit 😜 )

I noticed in the VirtualDomVertical module in _removeTopRow the row height is always the same even though the rows are not the same height.

I think the issue is the column height isn't recalculated after the rows are collapsed, so I've added a call to `calcHeight()` after the rows are collapsed.

Cheers,
Antonio