### PR TITLE
fix movable columns and range selection

### DIFF
--- a/src/js/modules/MoveColumns/MoveColumns.js
+++ b/src/js/modules/MoveColumns/MoveColumns.js
@@ -209,7 +209,7 @@ class MoveColumns extends Module{
 		
 		this.moveHover(e);
 
-		this.dispatch("column-start-move", e, this.moving);
+		this.dispatch("column-moving", e, this.moving);
 	}
 	
 	_bindMouseMove(){
@@ -267,8 +267,6 @@ class MoveColumns extends Module{
 				this.table.columnManager.moveColumnActual(this.moving, this.toCol, this.toColAfter);
 			}
 
-			this.dispatch("column-end-move", e, this.moving);
-			
 			this.moving = false;
 			this.toCol = false;
 			this.toColAfter = false;

--- a/src/js/modules/MoveColumns/MoveColumns.js
+++ b/src/js/modules/MoveColumns/MoveColumns.js
@@ -172,6 +172,13 @@ class MoveColumns extends Module{
 		headerElement = this.table.columnManager.getContentsElement(),
 		headersElement = this.table.columnManager.getHeadersElement();
 		
+		//Prevent moving columns when range selection is active
+		if(this.table.modules.selectRange && this.table.modules.selectRange.columnSelection){
+			if(this.table.modules.selectRange.mousedown && this.table.modules.selectRange.selecting === "column"){
+				return;
+			}
+		}
+
 		this.moving = column;
 		this.startX = (this.touchMove ? e.touches[0].pageX : e.pageX) - Helpers.elOffset(element).left;
 		
@@ -201,6 +208,8 @@ class MoveColumns extends Module{
 		}
 		
 		this.moveHover(e);
+
+		this.dispatch("column-start-move", e, this.moving);
 	}
 	
 	_bindMouseMove(){
@@ -257,6 +266,8 @@ class MoveColumns extends Module{
 			if(this.toCol){
 				this.table.columnManager.moveColumnActual(this.moving, this.toCol, this.toColAfter);
 			}
+
+			this.dispatch("column-end-move", e, this.moving);
 			
 			this.moving = false;
 			this.toCol = false;

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -84,6 +84,8 @@ class SelectRange extends Module {
 		this.subscribe("column-mousedown", this.handleColumnMouseDown.bind(this));
 		this.subscribe("column-mousemove", this.handleColumnMouseMove.bind(this));
 		this.subscribe("column-resized", this.handleColumnResized.bind(this));
+		this.subscribe("column-start-move", this.handleColumnStartMove.bind(this));
+		this.subscribe("column-end-move", this.handleColumnEndMove.bind(this));
 		this.subscribe("column-width", this.layoutChange.bind(this));
 		this.subscribe("column-height", this.layoutChange.bind(this));
 		this.subscribe("column-resized", this.layoutChange.bind(this));
@@ -279,8 +281,24 @@ class SelectRange extends Module {
 		});
 	}
 	
+	handleColumnStartMove(_event, column) {
+		this.resetRanges().setBounds(column);
+		this.overlay.style.visibility = "hidden";
+	}
+
+	handleColumnEndMove(_event, column) {
+		this.activeRange.setBounds(column);
+		this.layoutElement();
+	}
+
 	handleColumnMouseDown(event, column) {
 		if (event.button === 2 && (this.selecting === "column" || this.selecting === "all") && this.activeRange.occupiesColumn(column)) {
+			return;
+		}
+
+		//If columns are movable, allow dragging columns only if they are not
+		//selected. Dragging selected columns should move the columns instead.
+		if(this.table.options.movableColumns && this.selecting === "column" && this.activeRange.occupiesColumn(column)){
 			return;
 		}
 		

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -84,8 +84,8 @@ class SelectRange extends Module {
 		this.subscribe("column-mousedown", this.handleColumnMouseDown.bind(this));
 		this.subscribe("column-mousemove", this.handleColumnMouseMove.bind(this));
 		this.subscribe("column-resized", this.handleColumnResized.bind(this));
-		this.subscribe("column-start-move", this.handleColumnStartMove.bind(this));
-		this.subscribe("column-end-move", this.handleColumnEndMove.bind(this));
+		this.subscribe("column-moving", this.handleColumnMoving.bind(this));
+		this.subscribe("column-moved", this.handleColumnMoved.bind(this));
 		this.subscribe("column-width", this.layoutChange.bind(this));
 		this.subscribe("column-height", this.layoutChange.bind(this));
 		this.subscribe("column-resized", this.layoutChange.bind(this));
@@ -281,13 +281,13 @@ class SelectRange extends Module {
 		});
 	}
 	
-	handleColumnStartMove(_event, column) {
+	handleColumnMoving(_event, column) {
 		this.resetRanges().setBounds(column);
 		this.overlay.style.visibility = "hidden";
 	}
 
-	handleColumnEndMove(_event, column) {
-		this.activeRange.setBounds(column);
+	handleColumnMoved(from, _to, _after) {
+		this.activeRange.setBounds(from);
 		this.layoutElement();
 	}
 


### PR DESCRIPTION
This PR should allow us to have movable columns and also column range selection. Currently, enabling both options would results in weird behavior.

DEMO (to replicate): https://jsfiddle.net/4pqox6gu/

![mygif](https://github.com/olifolkerd/tabulator/assets/38707148/017a0389-db12-4ea0-88de-0c0bf7892490)