### PR TITLE
make autoFocus optional for SelectRange

### DIFF
--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -32,6 +32,7 @@ export default class SelectRange extends Module {
 		this.registerTableOption("selectableRangeRows", false); //enable selectable range
 		this.registerTableOption("selectableRangeClearCells", false); //allow clearing of active range
 		this.registerTableOption("selectableRangeClearCellsValue", undefined); //value for cleared active range
+		this.registerTableOption("selectableRangeAutoFocus", true); //focus on a cell after resetRanges
 		
 		this.registerTableFunction("getRangesData", this.getRangesData.bind(this));
 		this.registerTableFunction("getRanges", this.getRanges.bind(this));
@@ -878,7 +879,9 @@ export default class SelectRange extends Module {
 
 			if(cell){
 				range.setBounds(cell);
-				this.initializeFocus(cell);
+				if(this.options("selectableRangeAutoFocus")){
+					this.initializeFocus(cell);
+				}
 			}
 		}
 		


### PR DESCRIPTION
We recently found a bug related to SelectRange.

https://github.com/beekeeper-studio/beekeeper-studio/issues/2075

Basically, text editor (codemirror) outside tabulator becomes unusable when tabulator tries to gain focus. I think it's related to `document.createRange()` in SelectRange and the way that codemirror didn't handle that properly I guess (?).

So, I think it would be great to make the `autoFocus` optional.