### PR TITLE
Node bump for lint pipeline

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
- rollup doesn't support node 14 anymore

This should fix the linting pipeline