### PR TITLE
fix navigation with rowheader

### DIFF
--- a/src/js/modules/SelectRange/Range.js
+++ b/src/js/modules/SelectRange/Range.js
@@ -23,13 +23,6 @@ export default class Range extends CoreFeature{
 		this.start = {row:0, col:0};
 		this.end = {row:0, col:0};
 
-		if(this.rangeManager.rowHeader){
-			this.left = 1;
-			this.right = 1;
-			this.start.col = 1;
-			this.end.col = 1;
-		}
-		
 		this.initElement();
 		
 		setTimeout(() => {
@@ -84,21 +77,12 @@ export default class Range extends CoreFeature{
 	}
 	
 	setStartBound(element){
-		var row, col;
-		
 		if (element.type === "column") {
 			if(this.rangeManager.columnSelection){
 				this.setStart(0, element.getPosition() - 1);
 			}
 		}else{
-			row = element.row.position - 1;
-			col = element.column.getPosition() - 1;
-			
-			if (element.column === this.rangeManager.rowHeader) {
-				this.setStart(row, 1);
-			} else {
-				this.setStart(row, col);
-			}
+			this.setStart(element.row.position - 1, element.column.getPosition() - 1);
 		}
 	}
 	

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -457,6 +457,10 @@ export default class SelectRange extends Module {
 					break;
 			}
 		}
+
+		if(this.rowHeader && nextCol === 0) {
+			nextCol = 1;
+		}
 		
 		moved = nextCol !== rangeEdge.col || nextRow !== rangeEdge.row;
 		


### PR DESCRIPTION
Navigating to left with keyboard can make it select the `rowHeader`. 

Here's the demo to replicate: https://jsfiddle.net/dbjzcw0e/

![image](https://github.com/olifolkerd/tabulator/assets/38707148/42afceb5-4781-413b-bb12-53ef2a93e282)

- Try using keyboard to navigate to `rowHeader`
- Compare that with clicking `rowHeader` with mouse

To fix this, we can check if `rowHeader` exists in SelectRange. Range is not responsible for checking `rowHeader` for the most part anymore. Also, that seems to simplify the code a lot.