### PR TITLE
fix initial focus for SelectRange

### DIFF
--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -255,6 +255,8 @@ export default class SelectRange extends Module {
 	
 	initializeFocus(cell){
 		var range;
+
+		this.restoreFocus();
 		
 		try{
 			if (document.selection) { // IE


### PR DESCRIPTION
I'm not sure if I understand the purpose of `initializeFocus()` correctly, but tabulator doesn't seem to take focus after this function is called and navigating with keyboard doesn't work until clicking the table or calling `table.modules.selectRange.restoreFocus()`.