### PR TITLE
fix SelectRange keyboard navigation when there is a rowheader

### DIFF
--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -457,6 +457,10 @@ export default class SelectRange extends Module {
 					break;
 			}
 		}
+
+		if(this.rowHeader && nextCol === 0) {
+			nextCol = 1;
+		}
 		
 		moved = nextCol !== rangeEdge.col || nextRow !== rangeEdge.row;
 		


### PR DESCRIPTION
Pressing left arrow key can make it select the `rowHeader`. 

Here's the demo to replicate: https://jsfiddle.net/dbjzcw0e/

![image](https://github.com/olifolkerd/tabulator/assets/38707148/42afceb5-4781-413b-bb12-53ef2a93e282)

- Try to navigate to `rowHeader` using keyboard
- Compare that with clicking `rowHeader` with mouse