### PR TITLE
fix `range.getCells` does not return cell components

### DIFF
--- a/src/js/modules/SelectRange/RangeComponent.js
+++ b/src/js/modules/SelectRange/RangeComponent.js
@@ -22,7 +22,7 @@ export default class RangeComponent {
 	}
 
 	getCells() {
-		return this._range.getCells(true);
+		return this._range.getCells(true, true);
 	}
 
 	getStructuredCells() {


### PR DESCRIPTION
Calling `.getCells` from a Range Component did not return the components of cells, but instead the internal Cell instance.