### PR TITLE
Trap focus key navigation in Select Range

### DIFF
--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -383,14 +383,16 @@ export default class SelectRange extends Module {
 	
 	keyNavigate(dir, e){
 		if(this.navigate(false, false, dir)){
-			e.preventDefault();
+			// e.preventDefault();
 		}
+		e.preventDefault();
 	}
 	
 	keyNavigateRange(e, dir, jump, expand){
 		if(this.navigate(jump, expand, dir)){
-			e.preventDefault();
+			// e.preventDefault();
 		}
+		e.preventDefault();
 	}
 	
 	navigate(jump, expand, dir) {


### PR DESCRIPTION
It probably makes more sense if we can always trap the focus when enabling Select Range, IMHO.

I often spam pressing arrow keys if not with `ctrl` to go to the side of the table. But since tabulator doesn't call `.preventDefault` at certain condition, it instead does something else to the page. For example, it scrolls the page instead of staying in position, and in my browser, it can go to the previous page (by pressing `Ctrl+Left`).

To replicate:
- DEMO https://jsfiddle.net/xgdusamy/
- Try pressing `left/right/up/down` repeatedly

This fix can be very helpful too especially if a browser or an app has a custom keybinding. In my browser, I use `Ctrl+Left/Right` for going to previous/next page. It's annoying that I often accidently change my page when I no longer can go left and I press `Ctrl+Left`.
