### PR TITLE
Add fixed size for group divs to fix alignment with zoom

### DIFF
--- a/src/js/core/column/Column.js
+++ b/src/js/core/column/Column.js
@@ -640,6 +640,9 @@ export default class Column extends CoreFeature{
 			});
 			
 			this.contentElement.style.maxWidth = (childWidth - 1) + "px";
+			if (this.table.initialized) {
+				this.element.style.width = childWidth + "px";
+			}
 			
 			if(this.parent.isGroup){
 				this.parent.matchChildWidths();


### PR DESCRIPTION
This fixes #4407 

The problem occurs either with a screen zoom (default 150% for laptops) or browser zoom other than the default.

Root of the problem: floating point calculation errors of borders in browser [stackoverflow answer](https://stackoverflow.com/questions/19311611/zoom-out-bug-in-chrome-ie-etc-with-borders/19352124#19352124)

**Changes:**
- added fixed width for group element after header initialization. The initialized header is required to preserve the behavior of the offsetWidth property, which is used to calculate the column width.

**Testing:**
Tested on Chrome, Firefox, Edge. 
Firefox still have issue related to scrolling, but its not additive error anymore, just misalignment in some scrollbar positions