### PR TITLE
fix navigation conflict with SelectRange and Edit

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -178,6 +178,10 @@ export default class Edit extends Module{
 		
 		if(cell){
 			
+			if(cell.column.modules.edit.navigationBlocked){
+				return false;
+			}
+
 			if(e){
 				e.preventDefault();
 			}
@@ -208,6 +212,10 @@ export default class Edit extends Module{
 		
 		if(cell){
 			
+			if(cell.column.modules.edit.navigationBlocked){
+				return false;
+			}
+		
 			if(e){
 				e.preventDefault();
 			}
@@ -238,6 +246,10 @@ export default class Edit extends Module{
 		
 		if(cell){
 			
+			if(cell.column.modules.edit.navigationBlocked){
+				return false;
+			}
+		
 			if(e){
 				e.preventDefault();
 			}
@@ -259,6 +271,10 @@ export default class Edit extends Module{
 		
 		if(cell){
 			
+			if(cell.column.modules.edit.navigationBlocked){
+				return false;
+			}
+		
 			if(e){
 				e.preventDefault();
 			}
@@ -280,6 +296,10 @@ export default class Edit extends Module{
 		
 		if(cell){
 			
+			if(cell.column.modules.edit.navigationBlocked){
+				return false;
+			}
+		
 			if(e){
 				e.preventDefault();
 			}
@@ -301,6 +321,10 @@ export default class Edit extends Module{
 		
 		if(cell){
 			
+			if(cell.column.modules.edit.navigationBlocked){
+				return false;
+			}
+
 			if(e){
 				e.preventDefault();
 			}
@@ -401,6 +425,7 @@ export default class Edit extends Module{
 			convertEmptyValues:convertEmpty,
 			editorEmptyValue:column.definition.editorEmptyValue,
 			editorEmptyValueFunc:column.definition.editorEmptyValueFunc,
+			navigationBlocked: false,
 		};
 		
 		//set column editor

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -146,6 +146,7 @@ export default class SelectRange extends Module {
 			// Block editor from taking action so we can trigger edit by
 			// double clicking.
 			// column.modules.edit.blocked = true;
+			column.modules.edit.navigationBlocked = true;
 		}
 	}
 	


### PR DESCRIPTION
Using Up/Down Arrow keys while editing a cell can move the editor focus which is an uncommon behavior (comparing to Google Sheets and Ms. Excel). And it looks like we have 2 modules that can control table navigation => `SelectRange` module and `Edit` module. I think it's best if we can let **only** one module  to control navigation.

## Tabulator

![tabulator-nav](https://github.com/olifolkerd/tabulator/assets/38707148/534dc7a8-920f-434d-a9f2-607fd6d49f48)

Expected: Pressing arrow keys while editing should move the cursor inside the editor instead of continuing to navigate the table. 

## Google Sheets

![gsheet-nav](https://github.com/olifolkerd/tabulator/assets/38707148/39b75ecc-dfee-4f8f-9d9b-0dbad82c49e5)

