### PR TITLE
fix: SASS deprecation warning on tabulator themes

### DIFF
--- a/src/scss/themes/tabulator_midnight.scss
+++ b/src/scss/themes/tabulator_midnight.scss
@@ -156,9 +156,9 @@ $rangeHeaderTextHighlightBackground: #000000 !default; //header text color when 
 	border-color:#000;
 	background:$headerBackgroundColor;
 	
-	&.tabulator-toggle-on{
+	// &.tabulator-toggle-on{
 		// background:#25682b;
-	}
+	// }
 
 	.tabulator-toggle-switch{
 		border-color:#000;

--- a/src/scss/themes/tabulator_simple.scss
+++ b/src/scss/themes/tabulator_simple.scss
@@ -46,11 +46,11 @@ $footerActiveColor:#d00 !default; //footer bottom active text color
 		.tabulator-calcs-holder{
 			background:darken($headerBackgroundColor, 5%) !important;
 
+			border-bottom:1px solid $headerSeparatorColor;
+
 			.tabulator-row{
 				background:darken($headerBackgroundColor, 5%) !important;
 			}
-
-			border-bottom:1px solid $headerSeparatorColor;
 		}
 	}
 
@@ -66,11 +66,11 @@ $footerActiveColor:#d00 !default; //footer bottom active text color
 		.tabulator-calcs-holder{
 			background:darken($footerBackgroundColor, 5%) !important;
 
+			border-bottom:1px solid $footerBackgroundColor;
+
 			.tabulator-row{
 				background:darken($footerBackgroundColor, 5%) !important;
 			}
-
-			border-bottom:1px solid $footerBackgroundColor;
 		}
 
 		.tabulator-spreadsheet-tabs{

--- a/src/scss/themes/tabulator_site.scss
+++ b/src/scss/themes/tabulator_site.scss
@@ -76,12 +76,12 @@ $rangeHeaderTextHighlightBackground: #000000 !default; //header text color when 
 		.tabulator-calcs-holder{
 			background:lighten($headerBackgroundColor, 10%) !important;
 
+			border-top:1px solid $rowBorderColor;
+			border-bottom:none;
+
 			.tabulator-row{
 				background:lighten($headerBackgroundColor, 10%) !important;
 			}
-
-			border-top:1px solid $rowBorderColor;
-			border-bottom:none;
 		}
 	}
 
@@ -120,13 +120,13 @@ $rangeHeaderTextHighlightBackground: #000000 !default; //header text color when 
 
 			background:lighten($footerBackgroundColor, 10%) !important;
 
+			border-top:none;
+			border-bottom:1px solid $rowBorderColor;
+
 			.tabulator-row{
 				background:lighten($footerBackgroundColor, 10%) !important;
 				color:$headerTextColor !important;
 			}
-
-			border-top:none;
-			border-bottom:1px solid $rowBorderColor;
 		}
 
 		.tabulator-spreadsheet-tabs{

--- a/src/scss/themes/tabulator_site_dark.scss
+++ b/src/scss/themes/tabulator_site_dark.scss
@@ -138,13 +138,12 @@ $rangeHeaderTextHighlightBackground: #000000 !default; //header text color when 
 		.tabulator-calcs-holder{
 			background:lighten($headerBackgroundColor, 10%) !important;
 			border-top: 1px solid #393838;
+			border-top:1px solid $rowBorderColor;
+			border-bottom:none;
 			
 			.tabulator-row{
 				background-color: #292929 !important;
 			}
-			
-			border-top:1px solid $rowBorderColor;
-			border-bottom:none;
 		}
 		
 		.tabulator-cell{
@@ -217,13 +216,13 @@ $rangeHeaderTextHighlightBackground: #000000 !default; //header text color when 
 			background:lighten($footerBackgroundColor, 10%) !important;
 			border-bottom: 1px solid #393838;
 			
+			border-top:none;
+			border-bottom:1px solid $rowBorderColor;
+			
 			.tabulator-row{
 				background-color: #292929 !important;
 				color:$headerTextColor !important;
 			}
-			
-			border-top:none;
-			border-bottom:1px solid $rowBorderColor;
 		}
 		
 		.tabulator-spreadsheet-tabs{


### PR DESCRIPTION
While developing some of my apps that uses tabulator, these warnings started showing up:

![image](https://github.com/user-attachments/assets/a285aa23-b1ff-427d-b6c0-87308733fcfe)

This PR will fix these deprecation warnings by moving the border stylings from below the `.tabulator-row` class to above it. I'm assuming this will not impact anything as the styles being changed inside `.tabulator-row` is not manipulating border stylings. However, if there's a reason why it was placed below, then let me know and I can modify it so that we can follow this style declaration suggested by the SASS documentation:

![image](https://github.com/user-attachments/assets/a5266e4e-49eb-477d-a4a8-8c17b50095e4)

Here's some more info on this SASS breaking change: https://sass-lang.com/documentation/breaking-changes/mixed-decls/