### PR TITLE
Fix left/right movement of caret while editing with selectRange enabled.

### DIFF
--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -529,9 +529,8 @@ export default class SelectRange extends Module {
 			}
 
 			this.layoutElement();
-			
-			return true;
 		}
+		return true;
 	}
 	
 	rangeRemoved(removed){

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -404,16 +404,14 @@ export default class SelectRange extends Module {
 	
 	keyNavigate(dir, e){
 		if(this.navigate(false, false, dir)){
-			// e.preventDefault();
+			e.preventDefault();
 		}
-		e.preventDefault();
 	}
 	
 	keyNavigateRange(e, dir, jump, expand){
 		if(this.navigate(jump, expand, dir)){
-			// e.preventDefault();
+			e.preventDefault();
 		}
-		e.preventDefault();
 	}
 	
 	navigate(jump, expand, dir) {


### PR DESCRIPTION
This is a fix for #4563.

I'm not sure why `keyNavigate` and `keyNavigateRange` always called `e.preventDefault()`, but using just the commented line inside the `if` block fixes caret movement while editing.

Or is there any reason to call `e.preventDefault()` even if range-navigation is not allowed?
I think the event handlers should not have any effect in this case, as implemented in this PR.