### PR TITLE
fix range selection starting at top-left cell.

### DIFF
--- a/src/js/modules/SelectRange/Range.js
+++ b/src/js/modules/SelectRange/Range.js
@@ -20,8 +20,8 @@ export default class Range extends CoreFeature{
 		this.right = 0;
 		
 		this.table = table;
-		this.start = {row:0, col:0};
-		this.end = {row:0, col:0};
+		this.start = {row:undefined, col:undefined};
+		this.end = {row:undefined, col:undefined};
 
 		if(this.rangeManager.rowHeader){
 			this.left = 1;


### PR DESCRIPTION
fixes https://github.com/olifolkerd/tabulator/issues/4633

`Range` gets initialized with cell 0,0, when this `Range` gets added and `setBounds` is called with cell 0,0 no update is triggered and therefore no events are dispatched.

The solution is to set the initial `Range` start and end position as `undefined`