### PR TITLE
Fix popup positioning at the bottom edge of the screen

### DIFF
--- a/src/js/core/tools/Popup.js
+++ b/src/js/core/tools/Popup.js
@@ -209,7 +209,7 @@ export default class Popup extends CoreFeature{
 				}
 				
 			}else{
-				this.element.style.height = offsetHeight + "px";
+				this.element.style.top = (parseInt(this.element.style.top) - this.element.offsetHeight) + "px";
 			}
 		}
 	}


### PR DESCRIPTION
This should allow popups to start on the bottom edge even when there is no parent element.