### PR TITLE
fix(reactive): prevent overriding original functions with undefined on re-watching data

### DIFF
--- a/src/js/modules/ReactiveData/ReactiveData.js
+++ b/src/js/modules/ReactiveData/ReactiveData.js
@@ -217,7 +217,7 @@ export default class ReactiveData extends Module{
 					enumerable: true,
 					configurable:true,
 					writable:true,
-					value: this.origFuncs.key,
+					value: this.origFuncs[key],
 				});
 			}
 		}


### PR DESCRIPTION
https://codepen.io/timaxapa/pen/YPPPeJa?editors=1111

The issue is in using string `key` as property, not as `key`. Now we are losing original functions on subscribing to data after at least one `setData` call. 