### PR TITLE
fix: Bootstrap 5 dark mode table select

### DIFF
--- a/src/scss/themes/bootstrap/tabulator_bootstrap4.scss
+++ b/src/scss/themes/bootstrap/tabulator_bootstrap4.scss
@@ -218,26 +218,16 @@ $table-cell-padding-sm: 5px;
 
 			@media (hover:hover) and (pointer:fine){
 				&:hover{
-					background-color: $table-dark-hover-bg;
+					background-color: $table-dark-border-color;
 
 					.tabulator-cell{
-						background-color: inherit !important;
+						background-color: $table-dark-hover-bg;
 					}
 				}
 			}
 
 			&.tabulator-selected{
 				background-color:$rowSelectedBackground;
-
-				@media (hover:hover) and (pointer:fine){
-					&:hover{
-						background-color: $rowSelectedBackgroundHover;
-
-						.tabulator-cell{
-							background-color: inherit !important;
-						}
-					}
-				}
 			}
 		}
 

--- a/src/scss/themes/bootstrap/tabulator_bootstrap4.scss
+++ b/src/scss/themes/bootstrap/tabulator_bootstrap4.scss
@@ -218,16 +218,26 @@ $table-cell-padding-sm: 5px;
 
 			@media (hover:hover) and (pointer:fine){
 				&:hover{
-					background-color: $table-dark-border-color;
+					background-color: $table-dark-hover-bg;
 
 					.tabulator-cell{
-						background-color: $table-dark-hover-bg;
+						background-color: inherit !important;
 					}
 				}
 			}
 
 			&.tabulator-selected{
 				background-color:$rowSelectedBackground;
+
+				@media (hover:hover) and (pointer:fine){
+					&:hover{
+						background-color: $rowSelectedBackgroundHover;
+
+						.tabulator-cell{
+							background-color: inherit !important;
+						}
+					}
+				}
 			}
 		}
 

--- a/src/scss/themes/bootstrap/tabulator_bootstrap5.scss
+++ b/src/scss/themes/bootstrap/tabulator_bootstrap5.scss
@@ -177,7 +177,6 @@ $table-cell-padding-sm: 5px;
 	}
 
 	//Bootstrap theming classes
-
 	&.table{
 		background-color: $backgroundColor;
 
@@ -203,18 +202,23 @@ $table-cell-padding-sm: 5px;
 			background-color: $backgroundColor;
 			color: $table-color;
 
-			@media (hover:hover) and (pointer:fine){
-				&:hover{
-					background-color: $borderColor;
-
-					.tabulator-cell{
-						background-color: $rowSelectedBackgroundHover !important;
+			&.tabulator-selectable{
+				@media (hover:hover) and (pointer:fine){
+					&:hover{
+						background-color: $rowHoverBackground !important;
 					}
 				}
 			}
 
+
 			&.tabulator-selected{
 				background-color:$rowSelectedBackground !important;
+
+				@media (hover:hover) and (pointer:fine){
+					&:hover{
+						background-color: $rowSelectedBackgroundHover !important;
+					}
+				}
 			}
 		}
 
@@ -246,7 +250,7 @@ $table-cell-padding-sm: 5px;
 
 					@media (hover:hover) and (pointer:fine){
 						&.tabulator-selectable:hover{
-							background-color:$rowHoverBackground;
+							background-color:$rowHoverBackground !important;
 							cursor: pointer;
 						}
 
@@ -349,26 +353,26 @@ $table-cell-padding-sm: 5px;
 	}
 
 	&.table-striped{
-		&:not(.table-dark),
-		html:not([data-bs-theme="dark"]) &{
+		&:not(.table-dark) &,
+		html:not([data-bs-theme="dark"]) {
 			.tabulator-row{
 				&.tabulator-row-even{
 					background-color: $rowAltBackgroundColor;
+				}
 
-					&.tabulator-selected{
-						background-color:$rowSelectedBackground !important;
+				&.tabulator-selected{
+					background-color:$rowSelectedBackground !important;
+				}
+
+				@media (hover:hover) and (pointer:fine){
+					&.tabulator-selectable:hover{
+						background-color:$rowHoverBackground !important;
+						cursor: pointer;
 					}
-
-					@media (hover:hover) and (pointer:fine){
-						&.tabulator-selectable:hover{
-							background-color:$rowHoverBackground !important;
-							cursor: pointer;
-						}
-						
-						&.tabulator-selected:hover{
-							background-color:$rowSelectedBackgroundHover !important;
-							cursor: pointer;
-						}
+					
+					&.tabulator-selected:hover{
+						background-color:$rowSelectedBackgroundHover !important;
+						cursor: pointer;
 					}
 				}
 			}
@@ -380,9 +384,26 @@ $table-cell-padding-sm: 5px;
 				&:nth-child(even){
 					background-color: $table-dark-striped-bg !important;
 					.tabulator-cell{
-						background-color: inherit;
+						background-color: inherit !important;
+					}
+
+					&.tabulator-selected{
+						background-color:$rowSelectedBackground !important;
+					}
+
+					@media (hover:hover) and (pointer:fine){
+						&.tabulator-selectable:hover{
+							background-color:$table-dark-hover-bg !important;
+							cursor: pointer;
+						}
+						
+						&.tabulator-selected:hover{
+							background-color:$rowSelectedBackgroundHover !important;
+							cursor: pointer;
+						}
 					}
 				}
+
 			}
 		}
 	}
@@ -418,18 +439,31 @@ $table-cell-padding-sm: 5px;
 			background-color: $table-dark-bg;
 			color: $table-dark-color;
 
-			@media (hover:hover) and (pointer:fine){
-				&:hover{
-					background-color: $table-dark-border-color;
+			&.tabulator-selectable{
+				@media (hover:hover) and (pointer:fine){
+					&:hover{
+						background-color: $table-dark-hover-bg !important;
 
-					.tabulator-cell{
-						background-color: $rowSelectedBackgroundHover !important;
+						.tabulator-cell{
+							background-color: inherit !important;
+						}
 					}
 				}
 			}
 
+
 			&.tabulator-selected{
 				background-color:$rowSelectedBackground !important;
+
+				@media (hover:hover) and (pointer:fine){
+					&:hover{
+						background-color: $rowSelectedBackgroundHover !important;
+
+						.tabulator-cell{
+							background-color: inherit !important;
+						}
+					}
+				}
 			}
 		}
 

--- a/src/scss/themes/bootstrap/tabulator_bootstrap5.scss
+++ b/src/scss/themes/bootstrap/tabulator_bootstrap5.scss
@@ -208,13 +208,13 @@ $table-cell-padding-sm: 5px;
 					background-color: $borderColor;
 
 					.tabulator-cell{
-						background-color: $table-hover-bg;
+						background-color: $rowSelectedBackgroundHover !important;
 					}
 				}
 			}
 
 			&.tabulator-selected{
-				background-color:$rowSelectedBackground;
+				background-color:$rowSelectedBackground !important;
 			}
 		}
 
@@ -241,7 +241,7 @@ $table-cell-padding-sm: 5px;
 					background-color: $rowAltBackgroundColor;
 
 					&.tabulator-selected{
-						background-color:$rowSelectedBackground;
+						background-color:$rowSelectedBackground !important;
 					}
 
 					@media (hover:hover) and (pointer:fine){
@@ -251,7 +251,7 @@ $table-cell-padding-sm: 5px;
 						}
 
 						&.tabulator-selected:hover{
-							background-color:$rowSelectedBackgroundHover;
+							background-color:$rowSelectedBackgroundHover !important;
 							cursor: pointer;
 						}
 					}
@@ -263,7 +263,7 @@ $table-cell-padding-sm: 5px;
 			.tabulator-row{
 				&:nth-child(even){
 					.tabulator-cell{
-						background-color: $table-accent-bg;
+						background-color: inherit !important;
 					}
 				}
 			}
@@ -356,17 +356,17 @@ $table-cell-padding-sm: 5px;
 					background-color: $rowAltBackgroundColor;
 
 					&.tabulator-selected{
-						background-color:$rowSelectedBackground;
+						background-color:$rowSelectedBackground !important;
 					}
 
 					@media (hover:hover) and (pointer:fine){
 						&.tabulator-selectable:hover{
-							background-color:$rowHoverBackground;
+							background-color:$rowHoverBackground !important;
 							cursor: pointer;
 						}
 						
 						&.tabulator-selected:hover{
-							background-color:$rowSelectedBackgroundHover;
+							background-color:$rowSelectedBackgroundHover !important;
 							cursor: pointer;
 						}
 					}
@@ -409,7 +409,7 @@ $table-cell-padding-sm: 5px;
 
 		.tabulator-cell {
 			color: $table-dark-color;
-			background-color: $table-dark-bg;
+			background-color: inherit !important;
 			border-color: $table-dark-border-color;
 		}	
 
@@ -423,13 +423,13 @@ $table-cell-padding-sm: 5px;
 					background-color: $table-dark-border-color;
 
 					.tabulator-cell{
-						background-color: $table-dark-hover-bg;
+						background-color: $rowSelectedBackgroundHover !important;
 					}
 				}
 			}
 
 			&.tabulator-selected{
-				background-color:$table-dark-active-bg;
+				background-color:$rowSelectedBackground !important;
 			}
 		}
 
@@ -583,6 +583,7 @@ $table-cell-padding-sm: 5px;
 	border-bottom:1px solid $rowBorderColor;
 
 	.tabulator-cell{
+		background-color:inherit !important;
 		padding:$cellPadding;
 		border-right:none;
 

--- a/src/scss/themes/bootstrap/variables5.scss
+++ b/src/scss/themes/bootstrap/variables5.scss
@@ -702,7 +702,7 @@ $table-dark-striped-bg:      #2c3034;
 $table-dark-striped-color:   #fff;
 $table-dark-active-bg:       #373b3e;
 $table-dark-active-color:    #fff;
-$table-dark-hover-bg:        #323539;
+$table-dark-hover-bg:        $gray-600;
 $table-dark-hover-color:     #fff;
 
 


### PR DESCRIPTION
# Summary

This fixes row hovering for dark themed table selected and non-selected rows.

## Before

https://github.com/user-attachments/assets/9edb709b-97d7-4c40-9b8d-03e3dadc70a8


## After

https://github.com/user-attachments/assets/7f23c034-fad5-4007-8c29-dccb0292fccb

