### PR TITLE
Fix: Refine row click behavior for selection and deselection

### DIFF
--- a/src/js/modules/SelectRow/SelectRow.js
+++ b/src/js/modules/SelectRow/SelectRow.js
@@ -202,9 +202,8 @@ export default class SelectRow extends Module{
 		else if(e.ctrlKey || e.metaKey){
 			this.toggleRow(row);
 			this.lastClickedRow = row;
-		} else{
+		}else{
 			this.deselectRows(undefined, true);
-
 			if (this.selectedRows.length === 1 && this.isRowSelected(row)) {
 				// do nothing
 			} else {

--- a/src/js/modules/SelectRow/SelectRow.js
+++ b/src/js/modules/SelectRow/SelectRow.js
@@ -202,12 +202,16 @@ export default class SelectRow extends Module{
 		else if(e.ctrlKey || e.metaKey){
 			this.toggleRow(row);
 			this.lastClickedRow = row;
-		}else{
-			// If the row is already selected, deselect it. Otherwise, select it and deselect others.
-			if (this.isRowSelected(row)) {
-				this.deselectRows(row, true);
+		} else{
+			// Handle row clicked without SHIFT/CTRL:
+			// - If the clicked row is the only selected row: Deselect it.
+			// - If the clicked row is one of multiple selected rows: Make it the only selected row (deselect others).
+			// - If the clicked row is not currently selected: Deselect all others and select the clicked row.
+			this.deselectRows(undefined, true);
+
+			if (this.selectedRows.length === 1 && this.isRowSelected(row)) {
+				// do nothing
 			} else {
-				this.deselectRows(undefined, true);
 				this.selectRows(row);
 			}
 			this.lastClickedRow = row;

--- a/src/js/modules/SelectRow/SelectRow.js
+++ b/src/js/modules/SelectRow/SelectRow.js
@@ -203,10 +203,6 @@ export default class SelectRow extends Module{
 			this.toggleRow(row);
 			this.lastClickedRow = row;
 		} else{
-			// Handle row clicked without SHIFT/CTRL:
-			// - If the clicked row is the only selected row: Deselect it.
-			// - If the clicked row is one of multiple selected rows: Make it the only selected row (deselect others).
-			// - If the clicked row is not currently selected: Deselect all others and select the clicked row.
 			this.deselectRows(undefined, true);
 
 			if (this.selectedRows.length === 1 && this.isRowSelected(row)) {

--- a/src/js/modules/SelectRow/SelectRow.js
+++ b/src/js/modules/SelectRow/SelectRow.js
@@ -203,8 +203,13 @@ export default class SelectRow extends Module{
 			this.toggleRow(row);
 			this.lastClickedRow = row;
 		}else{
-			this.deselectRows(undefined, true);
-			this.selectRows(row);
+			// If the row is already selected, deselect it. Otherwise, select it and deselect others.
+			if (this.isRowSelected(row)) {
+				this.deselectRows(row, true);
+			} else {
+				this.deselectRows(undefined, true);
+				this.selectRows(row);
+			}
 			this.lastClickedRow = row;
 		}
 	}


### PR DESCRIPTION
This PR is to address an issue reported in https://github.com/olifolkerd/tabulator/issues/4442

### Current State
1. Select any row
2. Selecting the same row **doesn't deselect it**

### Expected State
1. Select any row
2. Selecting the same row again **will deselect it**

### Description
This PR tries to achieve the following behavior when a row is clicked without SHIFT/CTRL:
- If the clicked row is the only selected row: Deselect it.
- If the clicked row is one of multiple selected rows: Make it the only selected row (deselect others).
- If the clicked row is not currently selected: Deselect all others and select the clicked row.

This commit modifies the `handleComplexRowClick` function in the `SelectRow` module to correctly handle this scenario. Now, clicking an already selected row will deselect it, only if only it was the only one being selected previously.