### PR TITLE
Fix: script error during column resizing on mobile with resizableColumnGuide option enabled (#4757)

### DIFF
--- a/src/js/modules/ResizeColumns/ResizeColumns.js
+++ b/src/js/modules/ResizeColumns/ResizeColumns.js
@@ -210,9 +210,20 @@ export default class ResizeColumns extends Module{
 			component.modules.resize.handleEl.style.height = height;
 		}
 	}
+
+	getResizingClientX(e){
+		let x;
+		if (typeof e.clientX !== "undefined") return x = e.clientX;
+
+		const touch = this.table.options.resizableColumnGuide
+			? e.changedTouches?.[0]
+			: e.touches?.[0];
+
+		return x = touch?.clientX;
+	}
 	
 	resize(e, column){
-		var x = typeof e.clientX === "undefined" ? e.touches[0].clientX : e.clientX,
+		var x = this.getResizingClientX(e),
 		startDiff = x - this.startX,
 		moveDiff = x - this.latestX,
 		blockedBefore, blockedAfter;

--- a/src/js/modules/ResizeColumns/ResizeColumns.js
+++ b/src/js/modules/ResizeColumns/ResizeColumns.js
@@ -212,14 +212,13 @@ export default class ResizeColumns extends Module{
 	}
 
 	getResizingClientX(e){
-		let x;
-		if (typeof e.clientX !== "undefined") return x = e.clientX;
+		if (typeof e.clientX !== "undefined") return e.clientX;
 
 		const touch = this.table.options.resizableColumnGuide
 			? e.changedTouches?.[0]
 			: e.touches?.[0];
 
-		return x = touch?.clientX;
+		return touch?.clientX;
 	}
 	
 	resize(e, column){

--- a/src/js/modules/ResizeColumns/ResizeColumns.js
+++ b/src/js/modules/ResizeColumns/ResizeColumns.js
@@ -222,8 +222,14 @@ export default class ResizeColumns extends Module{
 	}
 	
 	resize(e, column){
-		var x = this.getResizingClientX(e),
-		startDiff = x - this.startX,
+		var x = this.getResizingClientX(e);
+
+		if (typeof x !== "number" || !isFinite(x)) {
+			console.warn("ResizeColumns: could not resolve pointer X from event", e);
+			return;
+		}
+
+		var startDiff = x - this.startX,
 		moveDiff = x - this.latestX,
 		blockedBefore, blockedAfter;
 


### PR DESCRIPTION
This PR fixes issue #4757. Cannot generate issue on jsfiddle… check sample below instead.

[issue4757.zip](https://github.com/user-attachments/files/21088592/issue4757.zip)

Whereas default mobile column resizing behavior of Tabulator is to trigger resizing event during `touchmove` event, the `resizableColumnGuide` option changes this behavior so that the event is triggered on `touchend` event instead.

Generally, `touchend` event occurs when all fingers are lifted from the display, which means that `event.touches.length` will be 0 and `event.touches[0]` will be undefined, and accessing `event.touches[0].clientX` will cause a script error.

So, I fixed to use `e.changedTouches[0].clientX` instead when the `resizableColumnGuide` option is enabled, to avoid script error.
