### PR TITLE
Add setMaxHeight and setMinHeight functions (#4224)

### DIFF
--- a/src/js/core/Tabulator.js
+++ b/src/js/core/Tabulator.js
@@ -855,6 +855,20 @@ class Tabulator extends ModuleBinder{
 		this.rowManager.initializeRenderer();
 		this.rowManager.redraw(true);
 	}
+
+	setMaxHeight(maxHeight){
+		this.options.maxHeight = isNaN(maxHeight) ? maxHeight : maxHeight + "px";
+		this.element.style.maxHeight = this.options.maxHeight;
+		this.rowManager.initializeRenderer();
+		this.rowManager.redraw(true);
+	}
+
+	setMinHeight(minHeight){
+		this.options.minHeight = isNaN(minHeight) ? minHeight : minHeight + "px";
+		this.element.style.minHeight = this.options.minHeight;
+		this.rowManager.initializeRenderer();
+		this.rowManager.redraw(true);
+	}
 	
 	//////////////////// Event Bus ///////////////////
 	


### PR DESCRIPTION
I ran into a similar issue described by https://github.com/olifolkerd/tabulator/issues/4224, where I was trying to change the table maxHeight after the table has been created.

**Please note:** I have not tested these functions myself, this _was_ just a simple copy of the `setHeight` function. There may be other complex issues that arise when trying to change these that have not been taken into account. Apologies in advance for already breaking the contribution guidelines.