### PR TITLE
fix(rendering): optimize row height initialization in VirtualDomVertical

### DIFF
--- a/src/js/core/rendering/renderers/VirtualDomVertical.js
+++ b/src/js/core/rendering/renderers/VirtualDomVertical.js
@@ -310,27 +310,29 @@ export default class VirtualDomVertical extends Renderer{
 				}
 
 				element.appendChild(rowFragment);
-				
-				// NOTE: The next 3 loops are separate on purpose
-				// This is to batch up the dom writes and reads which drastically improves performance 
+
+				// NOTE: The next 4 loops are separate on purpose
+				// This is to batch up the dom writes and reads which drastically improves performance
 
 				renderedRows.forEach((row) => {
 					row.rendered();
+				});
 
+				const rowsNeedingHeightInit = [];
+				renderedRows.forEach((row) => {
 					if(!row.heightInitialized) {
 						row.calcHeight(true);
+						rowsNeedingHeightInit.push(row);
 					}
 				});
 
-				renderedRows.forEach((row) => {
-					if(!row.heightInitialized) {
-						row.setCellHeight();
-					}
+				rowsNeedingHeightInit.forEach((row) => {
+					row.setCellHeight();
 				});
 
 				renderedRows.forEach((row) => {
 					rowHeight = row.getHeight();
-					
+
 					if(totalRowsRendered < topPad){
 						topPadHeight += rowHeight;
 					}else {


### PR DESCRIPTION
 1. Fixes a gap from PR #4134: Separates rendered() callbacks from height calculations
  2. Follows existing patterns: Matches the _quickNormalizeRowHeight() approach (lines
  632-640)
  3. Has precedent: Similar fix was already done for horizontal rendering (commit beff4503)
  4. Clear performance benefit: Reduces layout thrashing during initial render