### PR TITLE
Fix rowgroup roles on header/body (#4555)

### DIFF
--- a/src/js/core/ColumnManager.js
+++ b/src/js/core/ColumnManager.js
@@ -93,7 +93,6 @@ export default class ColumnManager extends CoreFeature {
 		var el = document.createElement("div");
 		
 		el.classList.add("tabulator-header-contents");
-		el.setAttribute("role", "rowgroup");
 		
 		return el;
 	}

--- a/src/js/core/RowManager.js
+++ b/src/js/core/RowManager.js
@@ -61,6 +61,7 @@ export default class RowManager extends CoreFeature{
 		
 		el.classList.add("tabulator-table");
 		el.setAttribute("role", "rowgroup");
+		el.setAttribute("id", "tabulator-table-body");
 		
 		return el;
 	}

--- a/src/js/core/Tabulator.js
+++ b/src/js/core/Tabulator.js
@@ -232,6 +232,7 @@ class Tabulator extends ModuleBinder{
 		
 		element.classList.add("tabulator");
 		element.setAttribute("role", "grid");
+		element.setAttribute("aria-owns", "tabulator-table-body");
 		
 		//empty element
 		while(element.firstChild) element.removeChild(element.firstChild);


### PR DESCRIPTION
**Summary**

This pull request partially addresses the #2 issue reported on #4555 . 

**Details of Changes**

1. Removed the rowgroup role set on tabulator-header-contents, as it's redundant with the rowgroup role set on tabulator-header . And according to ARIA specifications, a rowgroup element cannot be a parent of another rowgroup
2. Added an element ID to the tabulator-table element, and connect it to the grid element via aria-owns. This allows to establish a parent-child relationship between the two elements in the accessibility tree while keeping the tabulator-tableholder element without a role