### PR TITLE
Restore support basic, core Node-RED type for using node ui-tabulator.

### DIFF
--- a/src/js/modules/Edit/defaults/editors/date.js
+++ b/src/js/modules/Edit/defaults/editors/date.js
@@ -13,6 +13,8 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		
 		if(DT.isDateTime(value)){
 			newDatetime = value;
+		}else if(inputFormat === "x"){
+			newDatetime = DT.fromMillis(value);
 		}else if(inputFormat === "iso"){
 			newDatetime = DT.fromISO(String(value));
 		}else{
@@ -83,6 +85,10 @@ export default function(cell, onRendered, success, cancel, editorParams){
 						value = luxDate;
 						break;
 
+					case "x":
+						value = luxDate.toMillis();
+						break;
+						
 					case "iso":
 						value = luxDate.toISO();
 						break;

--- a/src/js/modules/Edit/defaults/editors/datetime.js
+++ b/src/js/modules/Edit/defaults/editors/datetime.js
@@ -31,6 +31,8 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		if(DT){
 			if(DT.isDateTime(cellValue)){
 				newDatetime = cellValue;
+			}else if(inputFormat === "x"){
+				newDatetime = DT.fromMillis(cellValue);	
 			}else if(inputFormat === "iso"){
 				newDatetime = DT.fromISO(String(cellValue));
 			}else{
@@ -70,6 +72,10 @@ export default function(cell, onRendered, success, cancel, editorParams){
 						value = luxDateTime;
 						break;
 
+					case "x":
+						value = luxDateTime.toMillis();
+						break;
+					
 					case "iso":
 						value = luxDateTime.toISO();
 						break;

--- a/src/js/modules/Edit/defaults/editors/time.js
+++ b/src/js/modules/Edit/defaults/editors/time.js
@@ -31,6 +31,8 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		if(DT){
 			if(DT.isDateTime(cellValue)){
 				newDatetime = cellValue;
+			}else if(inputFormat === "x"){
+				newDatetime = DT.fromMillis(cellValue);
 			}else if(inputFormat === "iso"){
 				newDatetime = DT.fromISO(String(cellValue));
 			}else{
@@ -71,6 +73,10 @@ export default function(cell, onRendered, success, cancel, editorParams){
 						value = luxTime;
 						break;
 
+					case "x":
+						value = luxTime.toMillis();
+						break;
+					
 					case "iso":
 						value = luxTime.toISO();
 						break;

--- a/src/js/modules/Format/defaults/formatters/datetime.js
+++ b/src/js/modules/Format/defaults/formatters/datetime.js
@@ -10,6 +10,8 @@ export default function(cell, formatterParams, onRendered){
 
 		if(DT.isDateTime(value)){
 			newDatetime = value;
+		}else if(inputFormat === "x"){
+			newDatetime = DT.fromMillis(value);	
 		}else if(inputFormat === "iso"){
 			newDatetime = DT.fromISO(String(value));
 		}else{

--- a/src/js/modules/Format/defaults/formatters/datetimediff.js
+++ b/src/js/modules/Format/defaults/formatters/datetimediff.js
@@ -13,6 +13,8 @@ export default function (cell, formatterParams, onRendered) {
 
 		if(DT.isDateTime(value)){
 			newDatetime = value;
+		}else if(inputFormat === "x"){
+			newDatetime = DT.fromMillis(value);	
 		}else if(inputFormat === "iso"){
 			newDatetime = DT.fromISO(String(value));
 		}else{

--- a/src/js/modules/Sort/defaults/sorters/datetime.js
+++ b/src/js/modules/Sort/defaults/sorters/datetime.js
@@ -9,6 +9,8 @@ export default function(a, b, aRow, bRow, column, dir, params){
 		if(!DT.isDateTime(a)){
 			if(format === "iso"){
 				a = DT.fromISO(String(a));
+			}else if(format === "x"){
+				a = DT.fromMillis(a);
 			}else{
 				a = DT.fromFormat(String(a), format);
 			}
@@ -17,6 +19,8 @@ export default function(a, b, aRow, bRow, column, dir, params){
 		if(!DT.isDateTime(b)){
 			if(format === "iso"){
 				b = DT.fromISO(String(b));
+			}else if(format === "x"){
+				b = DT.fromMillis(b);
 			}else{
 				b = DT.fromFormat(String(b), format);
 			}


### PR DESCRIPTION
Restore support basic, core Node-RED type for using node ui-tabulator.
After switching to luxon.js, support for Node-RED's basic, core Unix timestamp type was dropped. I've fixed file, returning the "x" type, similar to "iso." 