### PR TITLE
fix: scrolling errors when all groups are collapsed (#4219, #4525)

### DIFF
--- a/src/js/modules/GroupRows/Group.js
+++ b/src/js/modules/GroupRows/Group.js
@@ -592,7 +592,9 @@ export default class Group{
 	
 	reinitializeHeight(){}
 	
-	calcHeight(){}
+	calcHeight(){
+		this.outerHeight = this.element.offsetHeight;
+	}
 	
 	setCellHeight(){}
 	

--- a/src/js/modules/GroupRows/GroupRows.js
+++ b/src/js/modules/GroupRows/GroupRows.js
@@ -70,6 +70,7 @@ export default class GroupRows extends Module{
 			this.subscribe("rows-sample", this.rowSample.bind(this));
 			
 			this.subscribe("render-virtual-fill", this.virtualRenderFill.bind(this));
+			this.subscribe("table-layout", this.virtualRenderFill.bind(this));
 			
 			this.registerDisplayHandler(this.displayHandler, 20);
 			

--- a/test/e2e/group-scroll.html
+++ b/test/e2e/group-scroll.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="UTF-8" />
+	<title>Tabulator Group Scroll Test</title>
+	<link rel="stylesheet" href="../../dist/css/tabulator.min.css" />
+	<script src="../../dist/js/tabulator.js"></script>
+	<style>
+	body {
+		padding: 20px;
+		font-family: Arial, sans-serif;
+	}
+	#test-table {
+		width: 600px;
+	}
+	</style>
+</head>
+<body>
+	<h1>Tabulator Group Scroll Test</h1>
+	<div id="test-table"></div>
+
+	<script>
+		function generateData() {
+			const groupCount = 1000;
+			const rowsPerGroup = 3;
+			const data = [];
+			let id = 1;
+			for (let g = 0; g < groupCount; g++) {
+				for (let r = 0; r < rowsPerGroup; r++) {
+					data.push({
+						id: id++,
+						category: "Group " + g,
+						name: "Row " + g + "-" + r,
+						value: Math.round(Math.random() * 1000),
+					});
+				}
+			}
+			return data;
+		}
+
+		document.addEventListener("DOMContentLoaded", () => {
+			window.testTable = new Tabulator("#test-table", {
+				data: generateData(),
+				columns: [
+					{ title: "Name", field: "name" },
+					{ title: "Category", field: "category" },
+					{ title: "Value", field: "value", sorter: "number" },
+				],
+				height: "300px",
+				layout: "fitColumns",
+				groupBy: "category",
+				groupStartOpen: false,
+			});
+		});
+	</script>
+</body>
+</html>

--- a/test/e2e/group-scroll.spec.js
+++ b/test/e2e/group-scroll.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+import { join } from "path";
+
+const holderSel = ".tabulator-tableholder";
+
+// - #4219 (cannot scroll to the bottom)
+// - #4525 (expanding a group resets the scroll position)
+test.describe("Grouped table virtual scrolling (#4219, #4525)", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(`file://${join(__dirname, "group-scroll.html")}`);
+		await page.waitForSelector(".tabulator-row");
+		// position the pointer over the table so wheel events scroll it
+		await page.locator(holderSel).hover();
+	});
+
+	async function atBottom(page) {
+		return page.evaluate((sel) => {
+			const holder = document.querySelector(sel);
+			return holder.scrollTop >= holder.scrollHeight - holder.clientHeight - 1;
+		}, holderSel);
+	}
+
+	test("scrolls to the bottom through many collapsed groups (#4219)", async ({
+		page,
+	}) => {
+		// Scroll down with the mouse wheel until we reach the bottom or give up.
+		for (let i = 0; i < 250; i++) {
+			if (await atBottom(page)) {
+				break;
+			}
+			await page.mouse.wheel(0, 300);
+			await page.waitForTimeout(12);
+		}
+
+		const result = await page.evaluate((sel) => {
+			const holder = document.querySelector(sel);
+			return {
+				scrollTop: holder.scrollTop,
+				maxScroll: holder.scrollHeight - holder.clientHeight,
+			};
+		}, holderSel);
+
+		// Before the fix the view snapped back to the top after a few hundred
+		// pixels and never reached the bottom of a ~25,000px tall table.
+		expect(result.scrollTop).toBeGreaterThan(result.maxScroll * 0.9);
+	});
+
+	test("expanding a group below the fold keeps the scroll position (#4525)", async ({
+		page,
+	}) => {
+		// Wheel into the middle of the table, away from the top.
+		for (let i = 0; i < 45; i++) {
+			await page.mouse.wheel(0, 300);
+			await page.waitForTimeout(12);
+		}
+		await page.waitForTimeout(150);
+
+		const result = await page.evaluate((sel) => {
+			const holder = document.querySelector(sel);
+			const before = holder.scrollTop;
+
+			const groups = window.testTable.getGroups();
+			groups[Math.floor(groups.length / 2) + 2].toggle();
+
+			return new Promise((resolve) => {
+				setTimeout(
+					() => resolve({ before, after: holder.scrollTop }),
+					200,
+				);
+			});
+		}, holderSel);
+
+		// Before the fix expanding a group reset the scroll position to 0.
+		expect(result.before).toBeGreaterThan(0);
+		expect(result.after).toBeGreaterThan(result.before * 0.8);
+	});
+});


### PR DESCRIPTION
- fix horizontal scrollbar showing on initial display when there are groups
- fix tableholder not scrolling to bottom when there are groups
- fix tableholder jumping to top every time a group is collapsed/expanded

Implements Group.calcHeight() so group row height is non-zero, and re-runs GroupRows.virtualRenderFill() on table-layout so minWidth is recalculated after fitColumns has scaled the columns.

fixes #4219
fixes #4525