### PR TITLE
fix: correct data tree child row aggregation in column calcs

### DIFF
--- a/src/js/modules/ColumnCalcs/ColumnCalcs.js
+++ b/src/js/modules/ColumnCalcs/ColumnCalcs.js
@@ -411,7 +411,7 @@ export default class ColumnCalcs extends Module{
 
 			if(hasDataTreeColumnCalcs && row.modules.dataTree?.open){
 				this.rowsToData(dataTree.getFilteredTreeChildren(row)).forEach(dataRow =>{
-					data.push(row);
+					data.push(dataRow);
 				});
 			}
 		});

--- a/test/unit/modules/ColumnCalcs.spec.js
+++ b/test/unit/modules/ColumnCalcs.spec.js
@@ -147,6 +147,45 @@ describe('ColumnCalcs', function(){
 			expect(data[1].name).toBe("Jane");
 		});
 
+		test('rowsToData includes data tree child row data when child calcs are enabled', function(){
+			const childRows = [
+				{getData: function() { return {id: 2, value: 20}; }, modules: {}},
+				{getData: function() { return {id: 3, value: 30}; }, modules: {}},
+			];
+			const parentRow = {
+				getData: function() { return {id: 1, value: 10}; },
+				modules: {
+					dataTree: {
+						open: true,
+					},
+				},
+			};
+
+			const mockThis = {
+				rowsToData: ColumnCalcs.prototype.rowsToData,
+				table: {
+					options: {
+						dataTree: true,
+						dataTreeChildColumnCalcs: true,
+					},
+					modules: {
+						dataTree: {
+							getFilteredTreeChildren: jest.fn(() => childRows),
+						},
+					},
+				},
+			};
+
+			const data = ColumnCalcs.prototype.rowsToData.call(mockThis, [parentRow]);
+
+			expect(data).toEqual([
+				{id: 1, value: 10},
+				{id: 2, value: 20},
+				{id: 3, value: 30},
+			]);
+			expect(mockThis.table.modules.dataTree.getFilteredTreeChildren).toHaveBeenCalledWith(parentRow);
+		});
+
 		test('generateRowData creates calculation results', function(){
 			// Create mock data
 			const data = [


### PR DESCRIPTION
**Summary**
This fixes an issue where column calculations for data tree rows could include the parent row repeatedly instead of the child row data.

In the data tree calculation path, [rowsToData] iterates filtered child rows and should push each child row’s data into the calc input. The current logic pushes the parent [row] object instead, which causes incorrect summed values for expanded data tree branches.

- Fixes incorrect totals/sums for data tree child rows
- Affects column calculations when [dataTreeChildColumnCalcs] is enabled and a tree node is expanded

fixes #4705