### PR TITLE
Add !default for cell padding in table-sm

### DIFF
--- a/src/scss/themes/bootstrap/tabulator_bootstrap5.scss
+++ b/src/scss/themes/bootstrap/tabulator_bootstrap5.scss
@@ -37,7 +37,7 @@ $footerBorderColor:$pagination-border-color !default; //footer border color
 $footerSeparatorColor:$table-border-color !default; //footer bottom separator color
 $footerActiveColor:$pagination-active-color !default; //footer bottom active text color
 
-$table-cell-padding-sm: 5px;
+$table-cell-padding-sm: 5px !default; // cell padding in table-sm
 
 @use "../../tabulator.scss" with (
 	$backgroundColor: $backgroundColor,


### PR DESCRIPTION
Add the `!default` key so it's possible to override in custom themes