### PR TITLE
Fix Vue 3 reactivity issue with array mutation methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "tabulator-tables",
-      "version": "6.3.1",
+      "version": "6.4.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.26.9",
@@ -27,7 +27,8 @@
         "rollup": "^4.12.1",
         "rollup-plugin-license": "^3.3.1",
         "rollup-plugin-postcss": "^4.0.2",
-        "sass": "^1.93.2"
+        "sass": "^1.93.2",
+        "vue": "^3.5.35"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -320,9 +321,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -330,9 +331,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -379,13 +380,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1754,14 +1755,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3343,6 +3344,128 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
+      "integrity": "sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.35",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
+      "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.35",
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.35.tgz",
+      "integrity": "sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.35",
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/compiler-ssr": "3.5.35",
+        "@vue/shared": "3.5.35",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.35.tgz",
+      "integrity": "sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.35.tgz",
+      "integrity": "sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.35.tgz",
+      "integrity": "sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.35",
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.35.tgz",
+      "integrity": "sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.35",
+        "@vue/runtime-core": "3.5.35",
+        "@vue/shared": "3.5.35",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.35.tgz",
+      "integrity": "sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.35",
+        "@vue/shared": "3.5.35"
+      },
+      "peerDependencies": {
+        "vue": "3.5.35"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
+      "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -4262,6 +4385,13 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6725,9 +6855,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6898,9 +7028,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -7352,9 +7482,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7372,7 +7502,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9187,6 +9317,28 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
+      "integrity": "sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/compiler-sfc": "3.5.35",
+        "@vue/runtime-dom": "3.5.35",
+        "@vue/server-renderer": "3.5.35",
+        "@vue/shared": "3.5.35"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "rollup": "^4.12.1",
     "rollup-plugin-license": "^3.3.1",
     "rollup-plugin-postcss": "^4.0.2",
-    "sass": "^1.93.2"
+    "sass": "^1.93.2",
+    "vue": "^3.5.35"
   }
 }

--- a/src/js/modules/ReactiveData/ReactiveData.js
+++ b/src/js/modules/ReactiveData/ReactiveData.js
@@ -38,7 +38,14 @@ export default class ReactiveData extends Module{
 		this.unwatchData();
 		
 		this.data = data;
-		
+
+		//hold a reference to the instance methods so they can be restored in unwatchData.
+		//note: the actual array mutation below is performed via the native Array.prototype
+		//methods rather than these captured references. On framework reactive arrays (e.g.
+		//Vue 3) reading data.push returns an instrumented method that re-dispatches through
+		//this overridden property, which - while reactivity is blocked - would silently drop
+		//the underlying mutation and leave the array out of sync with the table (issue #4212).
+
 		//override array push function
 		this.origFuncs.push = data.push;
 		
@@ -56,8 +63,8 @@ export default class ReactiveData extends Module{
 						self.table.rowManager.addRowActual(arg, false);
 					});
 					
-					result = self.origFuncs.push.apply(data, arguments);
-					
+					result = Array.prototype.push.apply(data, arguments);
+
 					self.unblock("data-push");
 				}
 				
@@ -82,8 +89,8 @@ export default class ReactiveData extends Module{
 						self.table.rowManager.addRowActual(arg, true);
 					});
 					
-					result = self.origFuncs.unshift.apply(data, arguments);
-					
+					result = Array.prototype.unshift.apply(data, arguments);
+
 					self.unblock("data-unshift");
 				}
 				
@@ -112,7 +119,7 @@ export default class ReactiveData extends Module{
 						}
 					}
 
-					result = self.origFuncs.shift.call(data);
+					result = Array.prototype.shift.call(data);
 
 					self.unblock("data-shift");
 				}
@@ -141,8 +148,8 @@ export default class ReactiveData extends Module{
 						}
 					}
 
-					result = self.origFuncs.pop.call(data);
-					
+					result = Array.prototype.pop.call(data);
+
 					self.unblock("data-pop");
 				}
 
@@ -200,8 +207,8 @@ export default class ReactiveData extends Module{
 						self.table.rowManager.reRenderInPosition();
 					}
 
-					result = self.origFuncs.splice.apply(data, arguments);
-					
+					result = Array.prototype.splice.apply(data, arguments);
+
 					self.unblock("data-splice");
 				}
 				

--- a/src/js/modules/ReactiveData/ReactiveData.js
+++ b/src/js/modules/ReactiveData/ReactiveData.js
@@ -244,102 +244,108 @@ export default class ReactiveData extends Module{
 	
 	watchTreeChildren (row){
 		var self = this,
-		childField = row.getData()[this.table.options.dataTreeChildField],
-		origFuncs = {};
-		
+		childField = row.getData()[this.table.options.dataTreeChildField];
+
+		//note: the actual array mutation below is performed via the native Array.prototype
+		//methods. Reading childField.push on a framework reactive array (e.g. Vue 3) returns
+		//an instrumented method that re-dispatches through this overridden property; while
+		//reactivity is blocked that would silently drop the mutation and desync the child
+		//array from the table (issue #4212). Regular functions (not arrows) are required so
+		//that `arguments` refers to the call's arguments rather than watchTreeChildren's.
+
 		if(childField){
-			
-			origFuncs.push = childField.push;
-			
+
 			Object.defineProperty(childField, "push", {
 				enumerable: false,
 				configurable: true,
-				value: () => {
+				value: function(){
+					var result;
+
 					if(!self.blocked){
 						self.block("tree-push");
-						
-						var result = origFuncs.push.apply(childField, arguments);
-						this.rebuildTree(row);
-						
+
+						result = Array.prototype.push.apply(childField, arguments);
+						self.rebuildTree(row);
+
 						self.unblock("tree-push");
 					}
-					
+
 					return result;
 				}
 			});
-			
-			origFuncs.unshift = childField.unshift;
-			
+
 			Object.defineProperty(childField, "unshift", {
 				enumerable: false,
 				configurable: true,
-				value: () => {
+				value: function(){
+					var result;
+
 					if(!self.blocked){
 						self.block("tree-unshift");
-						
-						var result =  origFuncs.unshift.apply(childField, arguments);
-						this.rebuildTree(row);
-						
+
+						result = Array.prototype.unshift.apply(childField, arguments);
+						self.rebuildTree(row);
+
 						self.unblock("tree-unshift");
 					}
-					
+
 					return result;
 				}
 			});
-			
-			origFuncs.shift = childField.shift;
-			
+
 			Object.defineProperty(childField, "shift", {
 				enumerable: false,
 				configurable: true,
-				value: () => {
+				value: function(){
+					var result;
+
 					if(!self.blocked){
 						self.block("tree-shift");
-						
-						var result =  origFuncs.shift.call(childField);
-						this.rebuildTree(row);
-						
+
+						result = Array.prototype.shift.call(childField);
+						self.rebuildTree(row);
+
 						self.unblock("tree-shift");
 					}
-					
+
 					return result;
 				}
 			});
-			
-			origFuncs.pop = childField.pop;
-			
+
 			Object.defineProperty(childField, "pop", {
 				enumerable: false,
 				configurable: true,
-				value: () => {
+				value: function(){
+					var result;
+
 					if(!self.blocked){
 						self.block("tree-pop");
-						
-						var result =  origFuncs.pop.call(childField);
-						this.rebuildTree(row);
-						
+
+						result = Array.prototype.pop.call(childField);
+						self.rebuildTree(row);
+
 						self.unblock("tree-pop");
 					}
-					
+
 					return result;
 				}
 			});
-			
-			origFuncs.splice = childField.splice;
-			
+
 			Object.defineProperty(childField, "splice", {
 				enumerable: false,
 				configurable: true,
-				value: () => {
+				value: function(){
+					var result;
+
 					if(!self.blocked){
 						self.block("tree-splice");
-						
-						var result =  origFuncs.splice.apply(childField, arguments);
-						this.rebuildTree(row);
-						
+
+						result = Array.prototype.splice.apply(childField, arguments);
+						self.rebuildTree(row);
+
 						self.unblock("tree-splice");
 					}
-					
+
 					return result;
 				}
 			});

--- a/test/unit/modules/ReactiveDataReactivity.spec.js
+++ b/test/unit/modules/ReactiveDataReactivity.spec.js
@@ -1,0 +1,316 @@
+/**
+ * Cross-cutting reactivity regression tests for the ReactiveData module.
+ *
+ * These complement ReactiveDataVue3.spec.js (which uses real Vue 3 proxies)
+ * and the original ReactiveData.spec.js, focusing on two things:
+ *
+ *  1. "No framework" / plain arrays — the case used by React (state is plain
+ *     arrays) and Angular (Zone.js change detection over plain arrays), and the
+ *     baseline for everyone else. We assert the underlying array (and tree
+ *     child array) is actually mutated correctly, not just that the table-side
+ *     hooks fire. This guards against regressions in the normal path and also
+ *     covers the arrow-function `arguments` bug that previously corrupted
+ *     tree-child mutations even without any framework.
+ *
+ *  2. Generic Proxy-based reactivity — a minimal stand-in for proxy-based
+ *     reactive libraries (Vue 3, MobX, Valtio, Solid stores) that return an
+ *     instrumented method when a mutating array method is read and re-dispatch
+ *     it to the raw target. This proves the fix generalises beyond Vue's
+ *     specific implementation.
+ *
+ * Note: React and Angular do not use Proxy-based array instrumentation, so the
+ * meaningful guarantee for them is the plain-array path. Proxy-based libraries
+ * commonly paired with React (MobX/Valtio) are covered by the generic proxy
+ * suite.
+ */
+
+import ReactiveData from "../../../src/js/modules/ReactiveData/ReactiveData";
+
+function buildModule() {
+    const mockRowManager = {
+        addRowActual: jest.fn(),
+        getRowFromDataObject: jest.fn().mockReturnValue({ deleteActual: jest.fn() }),
+        reRenderInPosition: jest.fn(),
+        refreshActiveData: jest.fn(),
+    };
+
+    const mockTable = {
+        rowManager: mockRowManager,
+        modules: { dataTree: { initializeRow: jest.fn(), layoutRow: jest.fn() } },
+        options: {
+            reactiveData: true,
+            dataTree: true,
+            dataTreeChildField: "children",
+        },
+        eventBus: { subscribe: jest.fn() },
+    };
+
+    jest.spyOn(ReactiveData.prototype, "registerTableOption").mockImplementation(
+        function (key, value) {
+            this.table.options[key] = this.table.options[key] || value;
+        }
+    );
+    jest.spyOn(ReactiveData.prototype, "subscribe").mockImplementation(() => {});
+
+    const reactiveData = new ReactiveData(mockTable);
+    return { reactiveData, mockTable, mockRowManager };
+}
+
+/**
+ * Minimal proxy that mimics how proxy-based reactive libraries instrument
+ * array mutators: reading e.g. `arr.push` returns a wrapper that re-dispatches
+ * to the (possibly overridden) method on the raw target. This is the exact
+ * shape that triggered issue #4212.
+ */
+function makeReactiveProxy(arr) {
+    const MUTATORS = ["push", "unshift", "shift", "pop", "splice"];
+    return new Proxy(arr, {
+        get(target, key, receiver) {
+            if (typeof key === "string" && MUTATORS.includes(key)) {
+                return function (...args) {
+                    return target[key].apply(target, args);
+                };
+            }
+            return Reflect.get(target, key, receiver);
+        },
+    });
+}
+
+describe("ReactiveData reactivity (no framework / plain arrays)", () => {
+    let reactiveData;
+    let mockRowManager;
+
+    beforeEach(() => {
+        ({ reactiveData, mockRowManager } = buildModule());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    describe("top-level data array", () => {
+        it("push() mutates the array and notifies the table", () => {
+            const data = [{ id: 1 }];
+            reactiveData.watchData(data);
+
+            const row = { id: 2 };
+            const len = data.push(row);
+
+            expect(len).toBe(2);
+            expect(data).toEqual([{ id: 1 }, { id: 2 }]);
+            expect(mockRowManager.addRowActual).toHaveBeenCalledWith(row, false);
+        });
+
+        it("unshift() mutates the array and notifies the table", () => {
+            const data = [{ id: 1 }];
+            reactiveData.watchData(data);
+
+            const row = { id: 0 };
+            const len = data.unshift(row);
+
+            expect(len).toBe(2);
+            expect(data).toEqual([{ id: 0 }, { id: 1 }]);
+            expect(mockRowManager.addRowActual).toHaveBeenCalledWith(row, true);
+        });
+
+        it("pop() mutates the array and notifies the table", () => {
+            const last = { id: 2 };
+            const data = [{ id: 1 }, last];
+            reactiveData.watchData(data);
+
+            const result = data.pop();
+
+            expect(result).toEqual(last);
+            expect(data).toEqual([{ id: 1 }]);
+            expect(mockRowManager.getRowFromDataObject).toHaveBeenCalledWith(last);
+        });
+
+        it("shift() mutates the array and notifies the table", () => {
+            const first = { id: 1 };
+            const data = [first, { id: 2 }];
+            reactiveData.watchData(data);
+
+            const result = data.shift();
+
+            expect(result).toEqual(first);
+            expect(data).toEqual([{ id: 2 }]);
+            expect(mockRowManager.getRowFromDataObject).toHaveBeenCalledWith(first);
+        });
+
+        it("splice() mutates the array and notifies the table", () => {
+            const data = [{ id: 1 }, { id: 2 }, { id: 3 }];
+            reactiveData.watchData(data);
+
+            const newRow = { id: 9 };
+            const removed = data.splice(1, 1, newRow);
+
+            expect(removed).toEqual([{ id: 2 }]);
+            expect(data).toEqual([{ id: 1 }, { id: 9 }, { id: 3 }]);
+            expect(mockRowManager.reRenderInPosition).toHaveBeenCalled();
+        });
+    });
+
+    describe("tree child array (sub-objects)", () => {
+        let reactiveDataLocal;
+        let row;
+
+        const makeRow = (children) => ({
+            getData: () => ({ id: 1, children }),
+        });
+
+        beforeEach(() => {
+            ({ reactiveData: reactiveDataLocal } = buildModule());
+            jest.spyOn(reactiveDataLocal, "rebuildTree").mockImplementation(() => {});
+        });
+
+        it("push() pushes the given child (not the row) and rebuilds the tree", () => {
+            const children = [{ id: 2 }];
+            row = makeRow(children);
+            reactiveDataLocal.watchTreeChildren(row);
+
+            const child = { id: 3 };
+            children.push(child);
+
+            // Regression for the arrow-function `arguments` bug: the pushed value
+            // must be the child, never the row.
+            expect(children).toEqual([{ id: 2 }, { id: 3 }]);
+            expect(children[1]).toBe(child);
+            expect(reactiveDataLocal.rebuildTree).toHaveBeenCalledWith(row);
+        });
+
+        it("unshift() inserts the given child and rebuilds the tree", () => {
+            const children = [{ id: 2 }];
+            row = makeRow(children);
+            reactiveDataLocal.watchTreeChildren(row);
+
+            children.unshift({ id: 1 });
+
+            expect(children).toEqual([{ id: 1 }, { id: 2 }]);
+            expect(reactiveDataLocal.rebuildTree).toHaveBeenCalledWith(row);
+        });
+
+        it("pop() removes the last child and rebuilds the tree", () => {
+            const children = [{ id: 2 }, { id: 3 }];
+            row = makeRow(children);
+            reactiveDataLocal.watchTreeChildren(row);
+
+            const result = children.pop();
+
+            expect(result).toEqual({ id: 3 });
+            expect(children).toEqual([{ id: 2 }]);
+            expect(reactiveDataLocal.rebuildTree).toHaveBeenCalledWith(row);
+        });
+
+        it("shift() removes the first child and rebuilds the tree", () => {
+            const children = [{ id: 2 }, { id: 3 }];
+            row = makeRow(children);
+            reactiveDataLocal.watchTreeChildren(row);
+
+            const result = children.shift();
+
+            expect(result).toEqual({ id: 2 });
+            expect(children).toEqual([{ id: 3 }]);
+            expect(reactiveDataLocal.rebuildTree).toHaveBeenCalledWith(row);
+        });
+
+        it("splice() applies the given args and rebuilds the tree", () => {
+            const children = [{ id: 2 }, { id: 3 }, { id: 4 }];
+            row = makeRow(children);
+            reactiveDataLocal.watchTreeChildren(row);
+
+            const removed = children.splice(1, 1, { id: 9 });
+
+            expect(removed).toEqual([{ id: 3 }]);
+            expect(children).toEqual([{ id: 2 }, { id: 9 }, { id: 4 }]);
+            expect(reactiveDataLocal.rebuildTree).toHaveBeenCalledWith(row);
+        });
+    });
+
+    it("watchKey() still propagates a property change to the row", () => {
+        const data = { id: 1, name: "John" };
+        const mockRow = { getData: () => data, updateData: jest.fn() };
+
+        reactiveData.watchKey(mockRow, data, "name");
+        data.name = "Jane";
+
+        expect(data.name).toBe("Jane");
+        expect(mockRow.updateData).toHaveBeenCalledWith({ name: "Jane" });
+    });
+});
+
+describe("ReactiveData reactivity (generic Proxy-based: MobX / Valtio / Solid)", () => {
+    let reactiveData;
+    let mockRowManager;
+
+    beforeEach(() => {
+        ({ reactiveData, mockRowManager } = buildModule());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it("keeps a proxy-instrumented array in sync when push() is called", () => {
+        const raw = [{ id: 1 }];
+        const data = makeReactiveProxy(raw);
+
+        reactiveData.watchData(data);
+
+        const row = { id: 2 };
+        data.push(row);
+
+        expect(mockRowManager.addRowActual).toHaveBeenCalledWith(row, false);
+        expect(data).toHaveLength(2);
+        expect(raw).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it("keeps a proxy-instrumented array in sync when unshift() is called", () => {
+        const raw = [{ id: 1 }];
+        const data = makeReactiveProxy(raw);
+
+        reactiveData.watchData(data);
+
+        data.unshift({ id: 0 });
+
+        expect(data).toHaveLength(2);
+        expect(raw).toEqual([{ id: 0 }, { id: 1 }]);
+    });
+
+    it("keeps a proxy-instrumented array in sync when pop() is called", () => {
+        const raw = [{ id: 1 }, { id: 2 }];
+        const data = makeReactiveProxy(raw);
+
+        reactiveData.watchData(data);
+
+        const result = data.pop();
+
+        expect(result).toEqual({ id: 2 });
+        expect(raw).toEqual([{ id: 1 }]);
+    });
+
+    it("keeps a proxy-instrumented array in sync when shift() is called", () => {
+        const raw = [{ id: 1 }, { id: 2 }];
+        const data = makeReactiveProxy(raw);
+
+        reactiveData.watchData(data);
+
+        const result = data.shift();
+
+        expect(result).toEqual({ id: 1 });
+        expect(raw).toEqual([{ id: 2 }]);
+    });
+
+    it("keeps a proxy-instrumented array in sync when splice() is called", () => {
+        const raw = [{ id: 1 }, { id: 2 }, { id: 3 }];
+        const data = makeReactiveProxy(raw);
+
+        reactiveData.watchData(data);
+
+        const removed = data.splice(1, 1, { id: 9 });
+
+        expect(removed).toEqual([{ id: 2 }]);
+        expect(raw).toEqual([{ id: 1 }, { id: 9 }, { id: 3 }]);
+    });
+});

--- a/test/unit/modules/ReactiveDataVue3.spec.js
+++ b/test/unit/modules/ReactiveDataVue3.spec.js
@@ -1,0 +1,107 @@
+/**
+ * Reproduction test for GitHub issue #4212
+ * https://github.com/tabulator-tables/tabulator/issues/4212
+ *
+ * "vue3 reactivity problem: .push() causes Tabulator data to be updated
+ *  but does not update the array variable"
+ *
+ * When `reactiveData: true` is used together with a Vue 3 `reactive([])`
+ * array, calling `.push()` (and the other mutating array methods) updates
+ * the Tabulator display but leaves the underlying reactive array variable
+ * unchanged, so the table and the array fall out of sync.
+ *
+ * Root cause (as noted by the reporter, relating to "recursion"):
+ *   1. `watchData()` captures `this.origFuncs.push = data.push`. On a Vue 3
+ *      reactive proxy, reading `data.push` returns Vue's *instrumented* push,
+ *      not the native `Array.prototype.push`.
+ *   2. `Object.defineProperty(this.data, "push", ...)` installs Tabulator's
+ *      override on the raw array target behind the proxy.
+ *   3. When the user calls `reactiveArray.push(x)`, Vue's instrumented push
+ *      dispatches to `toRaw(arr).push`, which is Tabulator's override. The
+ *      override calls `addRowActual` (table updates) and then invokes the
+ *      captured `origFuncs.push` — which is Vue's instrumented push *again*.
+ *      That re-enters Tabulator's override, but reactivity is now `blocked`,
+ *      so the `if` branch is skipped and the *native* push is never executed.
+ *
+ * The net effect: the row is added to the table, but the reactive array is
+ * never actually mutated.
+ *
+ * These tests assert the CORRECT (in-sync) behaviour, so they currently FAIL,
+ * demonstrating the bug.
+ */
+
+import { reactive } from "vue";
+import ReactiveData from "../../../src/js/modules/ReactiveData/ReactiveData";
+
+describe("ReactiveData module with Vue 3 reactive arrays (issue #4212)", () => {
+    /** @type {ReactiveData} */
+    let reactiveData;
+    let mockTable;
+    let mockRowManager;
+
+    beforeEach(() => {
+        mockRowManager = {
+            // addRowActual is what actually inserts a row into the table render
+            addRowActual: jest.fn(),
+            getRowFromDataObject: jest.fn(),
+            reRenderInPosition: jest.fn(),
+            refreshActiveData: jest.fn(),
+        };
+
+        mockTable = {
+            rowManager: mockRowManager,
+            modules: {},
+            options: {
+                reactiveData: true,
+                dataTree: false,
+                dataTreeChildField: "children",
+            },
+            eventBus: { subscribe: jest.fn() },
+        };
+
+        jest.spyOn(ReactiveData.prototype, "registerTableOption").mockImplementation(
+            function (key, value) {
+                this.table.options[key] = this.table.options[key] || value;
+            }
+        );
+        jest.spyOn(ReactiveData.prototype, "subscribe").mockImplementation(() => {});
+
+        reactiveData = new ReactiveData(mockTable);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it("keeps a Vue 3 reactive array in sync with the table when push() is called", () => {
+        const data = reactive([{ id: 1, name: "John" }]);
+
+        reactiveData.watchData(data);
+
+        const newRow = { id: 2, name: "Bob" };
+        data.push(newRow);
+
+        // The table IS updated: addRowActual is called for the new row.
+        expect(mockRowManager.addRowActual).toHaveBeenCalledWith(newRow, false);
+
+        // The reactive array SHOULD also be updated, but with the bug it is not,
+        // leaving the table and the array out of sync.
+        expect(data).toHaveLength(2);
+        expect(data[1]).toEqual(newRow);
+    });
+
+    it("keeps a Vue 3 reactive array in sync with the table when unshift() is called", () => {
+        const data = reactive([{ id: 1, name: "John" }]);
+
+        reactiveData.watchData(data);
+
+        const newRow = { id: 0, name: "Alice" };
+        data.unshift(newRow);
+
+        expect(mockRowManager.addRowActual).toHaveBeenCalledWith(newRow, true);
+
+        expect(data).toHaveLength(2);
+        expect(data[0]).toEqual(newRow);
+    });
+});

--- a/test/unit/modules/ReactiveDataVue3.spec.js
+++ b/test/unit/modules/ReactiveDataVue3.spec.js
@@ -1,193 +1,42 @@
 /**
- * Reproduction test for GitHub issue #4212
+ * Real-Vue-3 smoke tests for issue #4212
  * https://github.com/tabulator-tables/tabulator/issues/4212
  *
- * "vue3 reactivity problem: .push() causes Tabulator data to be updated
- *  but does not update the array variable"
+ * "vue3 reactivity problem: .push() causes Tabulator data to be updated but
+ *  does not update the array variable"
  *
- * When `reactiveData: true` is used together with a Vue 3 `reactive([])`
- * array, calling `.push()` (and the other mutating array methods) updates
- * the Tabulator display but leaves the underlying reactive array variable
- * unchanged, so the table and the array fall out of sync.
+ * With reactiveData enabled and a Vue 3 reactive() array, the mutating array
+ * methods updated the table but left the reactive array unchanged, because the
+ * overrides re-dispatched through Vue's instrumented method while reactivity
+ * was blocked, dropping the native mutation. The fix performs the mutation via
+ * the native Array.prototype methods.
  *
- * Root cause (as noted by the reporter, relating to "recursion"):
- *   1. `watchData()` captures `this.origFuncs.push = data.push`. On a Vue 3
- *      reactive proxy, reading `data.push` returns Vue's *instrumented* push,
- *      not the native `Array.prototype.push`.
- *   2. `Object.defineProperty(this.data, "push", ...)` installs Tabulator's
- *      override on the raw array target behind the proxy.
- *   3. When the user calls `reactiveArray.push(x)`, Vue's instrumented push
- *      dispatches to `toRaw(arr).push`, which is Tabulator's override. The
- *      override calls `addRowActual` (table updates) and then invokes the
- *      captured `origFuncs.push` — which is Vue's instrumented push *again*.
- *      That re-enters Tabulator's override, but reactivity is now `blocked`,
- *      so the `if` branch is skipped and the *native* push is never executed.
- *
- * The net effect was: the row is added to the table, but the reactive array
- * is never actually mutated.
- *
- * The fix performs the underlying mutation with the native Array.prototype
- * methods instead of the (potentially instrumented) instance methods, so no
- * re-dispatch/recursion can occur. These tests assert the in-sync behaviour
- * and act as a regression guard.
+ * The framework-agnostic proof of the fix — all five mutators, add and remove,
+ * on the top-level data array and on tree-child arrays — lives in
+ * ReactiveDataReactivity.spec.js, which uses a generic Proxy plus plain arrays
+ * and needs no framework dependency. These two tests are the minimal
+ * confirmation that a *real* Vue 3 reactive() proxy behaves the same, covering
+ * both the top-level data array and a data-tree child array (sub-objects).
  */
 
 import { reactive } from "vue";
 import ReactiveData from "../../../src/js/modules/ReactiveData/ReactiveData";
 
-describe("ReactiveData module with Vue 3 reactive arrays (issue #4212)", () => {
+describe("ReactiveData with real Vue 3 reactive() arrays (issue #4212)", () => {
     /** @type {ReactiveData} */
     let reactiveData;
-    let mockTable;
     let mockRowManager;
 
     beforeEach(() => {
         mockRowManager = {
-            // addRowActual is what actually inserts a row into the table render
             addRowActual: jest.fn(),
-            getRowFromDataObject: jest.fn(),
+            getRowFromDataObject: jest.fn().mockReturnValue({ deleteActual: jest.fn() }),
             reRenderInPosition: jest.fn(),
             refreshActiveData: jest.fn(),
         };
 
-        mockTable = {
+        const mockTable = {
             rowManager: mockRowManager,
-            modules: {},
-            options: {
-                reactiveData: true,
-                dataTree: false,
-                dataTreeChildField: "children",
-            },
-            eventBus: { subscribe: jest.fn() },
-        };
-
-        jest.spyOn(ReactiveData.prototype, "registerTableOption").mockImplementation(
-            function (key, value) {
-                this.table.options[key] = this.table.options[key] || value;
-            }
-        );
-        jest.spyOn(ReactiveData.prototype, "subscribe").mockImplementation(() => {});
-
-        reactiveData = new ReactiveData(mockTable);
-    });
-
-    afterEach(() => {
-        jest.clearAllMocks();
-        jest.restoreAllMocks();
-    });
-
-    it("keeps a Vue 3 reactive array in sync with the table when push() is called", () => {
-        const data = reactive([{ id: 1, name: "John" }]);
-
-        reactiveData.watchData(data);
-
-        const newRow = { id: 2, name: "Bob" };
-        data.push(newRow);
-
-        // The table IS updated: addRowActual is called for the new row.
-        expect(mockRowManager.addRowActual).toHaveBeenCalledWith(newRow, false);
-
-        // The reactive array SHOULD also be updated, but with the bug it is not,
-        // leaving the table and the array out of sync.
-        expect(data).toHaveLength(2);
-        expect(data[1]).toEqual(newRow);
-    });
-
-    it("keeps a Vue 3 reactive array in sync with the table when unshift() is called", () => {
-        const data = reactive([{ id: 1, name: "John" }]);
-
-        reactiveData.watchData(data);
-
-        const newRow = { id: 0, name: "Alice" };
-        data.unshift(newRow);
-
-        expect(mockRowManager.addRowActual).toHaveBeenCalledWith(newRow, true);
-
-        expect(data).toHaveLength(2);
-        expect(data[0]).toEqual(newRow);
-    });
-
-    it("keeps a Vue 3 reactive array in sync with the table when pop() is called", () => {
-        const last = { id: 2, name: "Bob" };
-        const data = reactive([{ id: 1, name: "John" }, last]);
-
-        // The deletion is dispatched to the table via the row returned here.
-        mockRowManager.getRowFromDataObject.mockReturnValue({ deleteActual: jest.fn() });
-
-        reactiveData.watchData(data);
-
-        const result = data.pop();
-
-        // The table IS updated: the row for the removed item is looked up.
-        expect(mockRowManager.getRowFromDataObject).toHaveBeenCalledWith(last);
-
-        // The reactive array must actually shrink and return the popped value.
-        expect(result).toEqual(last);
-        expect(data).toHaveLength(1);
-        expect(data[0]).toEqual({ id: 1, name: "John" });
-    });
-
-    it("keeps a Vue 3 reactive array in sync with the table when shift() is called", () => {
-        const first = { id: 1, name: "John" };
-        const data = reactive([first, { id: 2, name: "Bob" }]);
-
-        mockRowManager.getRowFromDataObject.mockReturnValue({ deleteActual: jest.fn() });
-
-        reactiveData.watchData(data);
-
-        const result = data.shift();
-
-        expect(mockRowManager.getRowFromDataObject).toHaveBeenCalledWith(first);
-
-        expect(result).toEqual(first);
-        expect(data).toHaveLength(1);
-        expect(data[0]).toEqual({ id: 2, name: "Bob" });
-    });
-
-    it("keeps a Vue 3 reactive array in sync with the table when splice() is called", () => {
-        const data = reactive([
-            { id: 1, name: "John" },
-            { id: 2, name: "Bob" },
-            { id: 3, name: "Carol" },
-        ]);
-
-        mockRowManager.getRowFromDataObject.mockReturnValue({ deleteActual: jest.fn() });
-
-        reactiveData.watchData(data);
-
-        const newRow = { id: 4, name: "Dave" };
-        // Replace the middle element with a new one.
-        const removed = data.splice(1, 1, newRow);
-
-        // The reactive array must reflect the splice: removed item returned,
-        // new item present at the spliced position, length unchanged here.
-        expect(removed).toEqual([{ id: 2, name: "Bob" }]);
-        expect(data).toHaveLength(3);
-        expect(data[1]).toEqual(newRow);
-        expect(data.map((r) => r.id)).toEqual([1, 4, 3]);
-    });
-});
-
-/**
- * The same recursion problem also affected data-tree child arrays
- * (sub-objects) via watchTreeChildren(). On a Vue 3 reactive child array, the
- * mutating methods desynced exactly like the top-level data array. The
- * overrides were additionally arrow functions, so `arguments` resolved to
- * watchTreeChildren's own arguments rather than the call's, pushing the wrong
- * value. These tests exercise a real Vue 3 reactive child array.
- */
-describe("ReactiveData tree children with Vue 3 reactive arrays (issue #4212)", () => {
-    /** @type {ReactiveData} */
-    let reactiveData;
-    let mockTable;
-
-    const makeRow = (children) => ({
-        getData: () => ({ id: 1, name: "Parent", children }),
-    });
-
-    beforeEach(() => {
-        mockTable = {
-            rowManager: { refreshActiveData: jest.fn() },
             modules: { dataTree: { initializeRow: jest.fn(), layoutRow: jest.fn() } },
             options: {
                 reactiveData: true,
@@ -205,8 +54,6 @@ describe("ReactiveData tree children with Vue 3 reactive arrays (issue #4212)", 
         jest.spyOn(ReactiveData.prototype, "subscribe").mockImplementation(() => {});
 
         reactiveData = new ReactiveData(mockTable);
-        // rebuildTree pulls in the dataTree module; stub it and assert it fires.
-        jest.spyOn(reactiveData, "rebuildTree").mockImplementation(() => {});
     });
 
     afterEach(() => {
@@ -214,10 +61,25 @@ describe("ReactiveData tree children with Vue 3 reactive arrays (issue #4212)", 
         jest.restoreAllMocks();
     });
 
-    it("keeps a Vue 3 reactive child array in sync when push() is called", () => {
-        const children = reactive([{ id: 2, name: "Child A" }]);
-        const row = makeRow(children);
+    it("keeps the top-level reactive array in sync when push() is called", () => {
+        const data = reactive([{ id: 1, name: "John" }]);
+        reactiveData.watchData(data);
 
+        const newRow = { id: 2, name: "Bob" };
+        data.push(newRow);
+
+        // The table is updated...
+        expect(mockRowManager.addRowActual).toHaveBeenCalledWith(newRow, false);
+        // ...and the reactive array is actually mutated (the #4212 symptom).
+        expect(data).toHaveLength(2);
+        expect(data[1]).toEqual(newRow);
+    });
+
+    it("keeps a reactive tree-child array (sub-objects) in sync when push() is called", () => {
+        const children = reactive([{ id: 2, name: "Child A" }]);
+        const row = { getData: () => ({ id: 1, name: "Parent", children }) };
+
+        jest.spyOn(reactiveData, "rebuildTree").mockImplementation(() => {});
         reactiveData.watchTreeChildren(row);
 
         const newChild = { id: 3, name: "Child B" };
@@ -226,68 +88,5 @@ describe("ReactiveData tree children with Vue 3 reactive arrays (issue #4212)", 
         expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
         expect(children).toHaveLength(2);
         expect(children[1]).toEqual(newChild);
-    });
-
-    it("keeps a Vue 3 reactive child array in sync when unshift() is called", () => {
-        const children = reactive([{ id: 2, name: "Child A" }]);
-        const row = makeRow(children);
-
-        reactiveData.watchTreeChildren(row);
-
-        const newChild = { id: 1, name: "Child Z" };
-        children.unshift(newChild);
-
-        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
-        expect(children).toHaveLength(2);
-        expect(children[0]).toEqual(newChild);
-    });
-
-    it("keeps a Vue 3 reactive child array in sync when pop() is called", () => {
-        const last = { id: 3, name: "Child B" };
-        const children = reactive([{ id: 2, name: "Child A" }, last]);
-        const row = makeRow(children);
-
-        reactiveData.watchTreeChildren(row);
-
-        const result = children.pop();
-
-        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
-        expect(result).toEqual(last);
-        expect(children).toHaveLength(1);
-        expect(children[0]).toEqual({ id: 2, name: "Child A" });
-    });
-
-    it("keeps a Vue 3 reactive child array in sync when shift() is called", () => {
-        const first = { id: 2, name: "Child A" };
-        const children = reactive([first, { id: 3, name: "Child B" }]);
-        const row = makeRow(children);
-
-        reactiveData.watchTreeChildren(row);
-
-        const result = children.shift();
-
-        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
-        expect(result).toEqual(first);
-        expect(children).toHaveLength(1);
-        expect(children[0]).toEqual({ id: 3, name: "Child B" });
-    });
-
-    it("keeps a Vue 3 reactive child array in sync when splice() is called", () => {
-        const children = reactive([
-            { id: 2, name: "Child A" },
-            { id: 3, name: "Child B" },
-            { id: 4, name: "Child C" },
-        ]);
-        const row = makeRow(children);
-
-        reactiveData.watchTreeChildren(row);
-
-        const newChild = { id: 5, name: "Child D" };
-        const removed = children.splice(1, 1, newChild);
-
-        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
-        expect(removed).toEqual([{ id: 3, name: "Child B" }]);
-        expect(children).toHaveLength(3);
-        expect(children.map((c) => c.id)).toEqual([2, 5, 4]);
     });
 });

--- a/test/unit/modules/ReactiveDataVue3.spec.js
+++ b/test/unit/modules/ReactiveDataVue3.spec.js
@@ -167,3 +167,127 @@ describe("ReactiveData module with Vue 3 reactive arrays (issue #4212)", () => {
         expect(data.map((r) => r.id)).toEqual([1, 4, 3]);
     });
 });
+
+/**
+ * The same recursion problem also affected data-tree child arrays
+ * (sub-objects) via watchTreeChildren(). On a Vue 3 reactive child array, the
+ * mutating methods desynced exactly like the top-level data array. The
+ * overrides were additionally arrow functions, so `arguments` resolved to
+ * watchTreeChildren's own arguments rather than the call's, pushing the wrong
+ * value. These tests exercise a real Vue 3 reactive child array.
+ */
+describe("ReactiveData tree children with Vue 3 reactive arrays (issue #4212)", () => {
+    /** @type {ReactiveData} */
+    let reactiveData;
+    let mockTable;
+
+    const makeRow = (children) => ({
+        getData: () => ({ id: 1, name: "Parent", children }),
+    });
+
+    beforeEach(() => {
+        mockTable = {
+            rowManager: { refreshActiveData: jest.fn() },
+            modules: { dataTree: { initializeRow: jest.fn(), layoutRow: jest.fn() } },
+            options: {
+                reactiveData: true,
+                dataTree: true,
+                dataTreeChildField: "children",
+            },
+            eventBus: { subscribe: jest.fn() },
+        };
+
+        jest.spyOn(ReactiveData.prototype, "registerTableOption").mockImplementation(
+            function (key, value) {
+                this.table.options[key] = this.table.options[key] || value;
+            }
+        );
+        jest.spyOn(ReactiveData.prototype, "subscribe").mockImplementation(() => {});
+
+        reactiveData = new ReactiveData(mockTable);
+        // rebuildTree pulls in the dataTree module; stub it and assert it fires.
+        jest.spyOn(reactiveData, "rebuildTree").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it("keeps a Vue 3 reactive child array in sync when push() is called", () => {
+        const children = reactive([{ id: 2, name: "Child A" }]);
+        const row = makeRow(children);
+
+        reactiveData.watchTreeChildren(row);
+
+        const newChild = { id: 3, name: "Child B" };
+        children.push(newChild);
+
+        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
+        expect(children).toHaveLength(2);
+        expect(children[1]).toEqual(newChild);
+    });
+
+    it("keeps a Vue 3 reactive child array in sync when unshift() is called", () => {
+        const children = reactive([{ id: 2, name: "Child A" }]);
+        const row = makeRow(children);
+
+        reactiveData.watchTreeChildren(row);
+
+        const newChild = { id: 1, name: "Child Z" };
+        children.unshift(newChild);
+
+        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
+        expect(children).toHaveLength(2);
+        expect(children[0]).toEqual(newChild);
+    });
+
+    it("keeps a Vue 3 reactive child array in sync when pop() is called", () => {
+        const last = { id: 3, name: "Child B" };
+        const children = reactive([{ id: 2, name: "Child A" }, last]);
+        const row = makeRow(children);
+
+        reactiveData.watchTreeChildren(row);
+
+        const result = children.pop();
+
+        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
+        expect(result).toEqual(last);
+        expect(children).toHaveLength(1);
+        expect(children[0]).toEqual({ id: 2, name: "Child A" });
+    });
+
+    it("keeps a Vue 3 reactive child array in sync when shift() is called", () => {
+        const first = { id: 2, name: "Child A" };
+        const children = reactive([first, { id: 3, name: "Child B" }]);
+        const row = makeRow(children);
+
+        reactiveData.watchTreeChildren(row);
+
+        const result = children.shift();
+
+        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
+        expect(result).toEqual(first);
+        expect(children).toHaveLength(1);
+        expect(children[0]).toEqual({ id: 3, name: "Child B" });
+    });
+
+    it("keeps a Vue 3 reactive child array in sync when splice() is called", () => {
+        const children = reactive([
+            { id: 2, name: "Child A" },
+            { id: 3, name: "Child B" },
+            { id: 4, name: "Child C" },
+        ]);
+        const row = makeRow(children);
+
+        reactiveData.watchTreeChildren(row);
+
+        const newChild = { id: 5, name: "Child D" };
+        const removed = children.splice(1, 1, newChild);
+
+        expect(reactiveData.rebuildTree).toHaveBeenCalledWith(row);
+        expect(removed).toEqual([{ id: 3, name: "Child B" }]);
+        expect(children).toHaveLength(3);
+        expect(children.map((c) => c.id)).toEqual([2, 5, 4]);
+    });
+});

--- a/test/unit/modules/ReactiveDataVue3.spec.js
+++ b/test/unit/modules/ReactiveDataVue3.spec.js
@@ -23,11 +23,13 @@
  *      That re-enters Tabulator's override, but reactivity is now `blocked`,
  *      so the `if` branch is skipped and the *native* push is never executed.
  *
- * The net effect: the row is added to the table, but the reactive array is
- * never actually mutated.
+ * The net effect was: the row is added to the table, but the reactive array
+ * is never actually mutated.
  *
- * These tests assert the CORRECT (in-sync) behaviour, so they currently FAIL,
- * demonstrating the bug.
+ * The fix performs the underlying mutation with the native Array.prototype
+ * methods instead of the (potentially instrumented) instance methods, so no
+ * re-dispatch/recursion can occur. These tests assert the in-sync behaviour
+ * and act as a regression guard.
  */
 
 import { reactive } from "vue";

--- a/test/unit/modules/ReactiveDataVue3.spec.js
+++ b/test/unit/modules/ReactiveDataVue3.spec.js
@@ -106,4 +106,64 @@ describe("ReactiveData module with Vue 3 reactive arrays (issue #4212)", () => {
         expect(data).toHaveLength(2);
         expect(data[0]).toEqual(newRow);
     });
+
+    it("keeps a Vue 3 reactive array in sync with the table when pop() is called", () => {
+        const last = { id: 2, name: "Bob" };
+        const data = reactive([{ id: 1, name: "John" }, last]);
+
+        // The deletion is dispatched to the table via the row returned here.
+        mockRowManager.getRowFromDataObject.mockReturnValue({ deleteActual: jest.fn() });
+
+        reactiveData.watchData(data);
+
+        const result = data.pop();
+
+        // The table IS updated: the row for the removed item is looked up.
+        expect(mockRowManager.getRowFromDataObject).toHaveBeenCalledWith(last);
+
+        // The reactive array must actually shrink and return the popped value.
+        expect(result).toEqual(last);
+        expect(data).toHaveLength(1);
+        expect(data[0]).toEqual({ id: 1, name: "John" });
+    });
+
+    it("keeps a Vue 3 reactive array in sync with the table when shift() is called", () => {
+        const first = { id: 1, name: "John" };
+        const data = reactive([first, { id: 2, name: "Bob" }]);
+
+        mockRowManager.getRowFromDataObject.mockReturnValue({ deleteActual: jest.fn() });
+
+        reactiveData.watchData(data);
+
+        const result = data.shift();
+
+        expect(mockRowManager.getRowFromDataObject).toHaveBeenCalledWith(first);
+
+        expect(result).toEqual(first);
+        expect(data).toHaveLength(1);
+        expect(data[0]).toEqual({ id: 2, name: "Bob" });
+    });
+
+    it("keeps a Vue 3 reactive array in sync with the table when splice() is called", () => {
+        const data = reactive([
+            { id: 1, name: "John" },
+            { id: 2, name: "Bob" },
+            { id: 3, name: "Carol" },
+        ]);
+
+        mockRowManager.getRowFromDataObject.mockReturnValue({ deleteActual: jest.fn() });
+
+        reactiveData.watchData(data);
+
+        const newRow = { id: 4, name: "Dave" };
+        // Replace the middle element with a new one.
+        const removed = data.splice(1, 1, newRow);
+
+        // The reactive array must reflect the splice: removed item returned,
+        // new item present at the spliced position, length unchanged here.
+        expect(removed).toEqual([{ id: 2, name: "Bob" }]);
+        expect(data).toHaveLength(3);
+        expect(data[1]).toEqual(newRow);
+        expect(data.map((r) => r.id)).toEqual([1, 4, 3]);
+    });
 });


### PR DESCRIPTION
## Summary
Fixes issue #4212 where using `reactiveData: true` with Vue 3 `reactive()` arrays caused array mutation methods (push, unshift, pop, shift, splice) to update the Tabulator display but leave the underlying reactive array unchanged, resulting in the table and array falling out of sync.

## Root Cause
When reading instance methods from a Vue 3 reactive proxy (e.g., `data.push`), Vue returns an instrumented version that re-dispatches through the proxy. The original code captured these instrumented methods and called them during mutations. This caused:

1. User calls `reactiveArray.push(x)` → Vue's instrumented push
2. Vue dispatches to `toRaw(arr).push` → Tabulator's override
3. Tabulator's override calls `addRowActual` then invokes the captured `origFuncs.push`
4. This re-enters Tabulator's override, but reactivity is blocked, so the native mutation is skipped
5. Result: table updates but the reactive array is never actually mutated

## Key Changes
- Modified all array mutation method overrides (push, unshift, pop, shift, splice) to use native `Array.prototype` methods directly instead of the captured instance methods
- This prevents re-dispatch/recursion through framework instrumentation while still performing the actual array mutations
- Added comprehensive test suite with Vue 3 reactive arrays to verify the fix and prevent regression

## Implementation Details
- Changed `self.origFuncs.push.apply(data, arguments)` to `Array.prototype.push.apply(data, arguments)` (and similar for other methods)
- The captured `origFuncs` references are still maintained for potential restoration in `unwatchData()`, but are no longer used for mutations
- Added Vue 3 as a dev dependency to support the test suite

https://claude.ai/code/session_01CRpXUMBxEwu6uajQLcrbLw