### PR TITLE
Fix BigInt handling in sorter detection and formatters

### DIFF
--- a/test/unit/core/ColumnManager.spec.js
+++ b/test/unit/core/ColumnManager.spec.js
@@ -1,0 +1,43 @@
+import TabulatorFull from "../../../src/js/core/TabulatorFull";
+
+describe("ColumnManager - calculateSorterFromValue with BigInt values", () => {
+    // Fix https://github.com/tabulator-tables/tabulator/pull/4894
+    // isNaN(value) threw "Cannot convert a BigInt value to a number" when
+    // auto-generating columns from row data containing BigInt values.
+
+    /** @type {TabulatorFull} */
+    let tabulator;
+
+    afterEach(() => {
+        tabulator?.destroy();
+        document.getElementById("tabulator")?.remove();
+    });
+
+    function buildTable(options) {
+        const el = document.createElement("div");
+        el.id = "tabulator";
+        document.body.appendChild(el);
+        tabulator = new TabulatorFull("#tabulator", options);
+        return new Promise((resolve) => {
+            tabulator.on("tableBuilt", () => resolve());
+        });
+    }
+
+    it("detects a number sorter for a BigInt value without throwing", async () => {
+        await buildTable({ data: [{ id: 1 }], columns: [{ field: "id" }] });
+        const columnManager = tabulator.columnManager;
+        expect(() => columnManager.calculateSorterFromValue(10n)).not.toThrow();
+        expect(columnManager.calculateSorterFromValue(10n)).toBe("number");
+    });
+
+    it("builds auto columns from BigInt row data without throwing", async () => {
+        await buildTable({
+            autoColumns: true,
+            data: [{ id: 1, big: 100n }],
+        });
+
+        const column = tabulator.columnManager.findColumn("big");
+        expect(column).toBeTruthy();
+        expect(column.definition.sorter).toBe("number");
+    });
+});

--- a/test/unit/modules/Format.spec.js
+++ b/test/unit/modules/Format.spec.js
@@ -169,3 +169,42 @@ describe("Format module - 'x' (epoch milliseconds) input format", () => {
         expect(cellEl.innerHTML).toBe("3");
     });
 });
+
+describe("Format module - formatters with BigInt values", () => {
+    // Fix https://github.com/tabulator-tables/tabulator/pull/4895
+    // The star formatter called isNaN() on the raw cell value, which throws
+    // "Cannot convert a BigInt value to a number" for BigInt values. Number.isNaN()
+    // never coerces its argument, so it is safe for BigInt (and any other type).
+
+    /** @type {TabulatorFull} */
+    let tabulator;
+
+    const buildTable = async (columns, data) => {
+        const el = document.createElement("div");
+        el.id = "tabulator";
+        document.body.appendChild(el);
+        tabulator = new TabulatorFull("#tabulator", { data, columns });
+        return new Promise((resolve) => {
+            tabulator.on("tableBuilt", () => resolve());
+        });
+    };
+
+    afterEach(() => {
+        tabulator?.destroy();
+        document.getElementById("tabulator")?.remove();
+    });
+
+    it("star formatter renders the correct number of stars for a BigInt value", async () => {
+        await buildTable(
+            [{ title: "Rating", field: "rating", formatter: "star", formatterParams: { stars: 5 } }],
+            [{ id: 1, rating: 3n }]
+        );
+
+        const cellEl = tabulator.getRows()[0].getCell("rating").getElement();
+        const stars = cellEl.querySelectorAll("svg");
+        const activeStars = cellEl.querySelectorAll('polygon[fill="#FFEA00"]');
+
+        expect(stars.length).toBe(5);
+        expect(activeStars.length).toBe(3);
+    });
+});

--- a/test/unit/modules/Sort.spec.js
+++ b/test/unit/modules/Sort.spec.js
@@ -206,3 +206,54 @@ describe("Sort module - datetime sorter with 'x' (epoch milliseconds) format", (
         expect(sorted.map((row) => row.data.id)).toEqual([3, 1, 2]);
     });
 });
+
+describe("Sort module - BigInt values with auto-detected sorter", () => {
+    // Fix https://github.com/tabulator-tables/tabulator/pull/4894
+    // isNaN(value) threw "Cannot convert a BigInt value to a number" when
+    // guessing a sorter for a column holding BigInt values.
+
+    /** @type {TabulatorFull} */
+    let tabulator;
+    /** @type {Sort} */
+    let sortMod;
+
+    beforeEach(async () => {
+        const el = document.createElement("div");
+        el.id = "tabulator";
+        document.body.appendChild(el);
+        tabulator = new TabulatorFull("#tabulator", {
+            data: [
+                { id: 1, big: 30n },
+                { id: 2, big: 10n },
+                { id: 3, big: 20n },
+            ],
+            // no sorter defined, so it must be auto-detected via findSorter
+            columns: [
+                { title: "ID", field: "id", sorter: "number" },
+                { title: "Big", field: "big" },
+            ],
+        });
+        sortMod = tabulator.module("sort");
+        return new Promise((resolve) => {
+            tabulator.on("tableBuilt", () => resolve());
+        });
+    });
+
+    afterEach(() => {
+        tabulator.destroy();
+        document.getElementById("tabulator")?.remove();
+    });
+
+    it("auto-detects a number sorter for a BigInt column without throwing", () => {
+        const column = tabulator.columnManager.findColumn("big");
+        expect(() => sortMod.findSorter(column)).not.toThrow();
+        expect(sortMod.findSorter(column)).toBe(Sort.sorters.number);
+    });
+
+    it("sorts BigInt values numerically when the sorter is auto-detected", () => {
+        const column = tabulator.columnManager.findColumn("big");
+        sortMod.setSort(column, "asc");
+        const sorted = sortMod.sort(tabulator.rowManager.activeRows);
+        expect(sorted.map((row) => row.data.id)).toEqual([2, 3, 1]);
+    });
+});


### PR DESCRIPTION
## Summary
Fix issues where `isNaN()` was called on BigInt values, which throws "Cannot convert a BigInt value to a number". Replace unsafe `isNaN()` calls with `Number.isNaN()` which safely handles all types without coercion.

## Changes
- **Sort module**: Updated `findSorter()` to use `Number.isNaN()` instead of `isNaN()` when auto-detecting sorters for columns with BigInt values
- **ColumnManager module**: Updated `calculateSorterFromValue()` to use `Number.isNaN()` instead of `isNaN()` when auto-generating column definitions from row data containing BigInt values
- **Format module**: Updated the star formatter to use `Number.isNaN()` instead of `isNaN()` when rendering star ratings for BigInt values

## Tests Added
- Added comprehensive test suite for Sort module with BigInt auto-detection
- Added test suite for ColumnManager with BigInt value handling
- Added test suite for Format module star formatter with BigInt values

All tests verify that BigInt values are handled correctly without throwing errors and are sorted/formatted as expected.

Fix https://github.com/tabulator-tables/tabulator/pull/4894
Fix https://github.com/tabulator-tables/tabulator/pull/4895

https://claude.ai/code/session_017e1i1mc795CkBbUrmPmNuy