### PR TITLE
perf(core): clone row template and slice active rows

### DIFF
--- a/src/js/core/RowManager.js
+++ b/src/js/core/RowManager.js
@@ -768,7 +768,7 @@ export default class RowManager extends CoreFeature{
 	}
 	
 	setActiveRows(activeRows){
-		this.activeRows = this.activeRows = Object.assign([], activeRows);
+		this.activeRows = activeRows.slice();
 		this.activeRowsCount = this.activeRows.length;
 	}
 	

--- a/src/js/core/row/Row.js
+++ b/src/js/core/row/Row.js
@@ -3,6 +3,9 @@ import RowComponent from './RowComponent.js';
 import Helpers from '../tools/Helpers.js';
 
 export default class Row extends CoreFeature{
+	
+	static rowTemplate = Row.createRowTemplate();
+	
 	constructor (data, parent, type = "row"){
 		super(parent.table);
 		
@@ -25,6 +28,7 @@ export default class Row extends CoreFeature{
 		
 		this.created = false;
 		
+		
 		this.setData(data);
 	}
 	
@@ -36,12 +40,7 @@ export default class Row extends CoreFeature{
 	}
 	
 	createElement (){
-		var el = document.createElement("div");
-		
-		el.classList.add("tabulator-row");
-		el.setAttribute("role", "row");
-		
-		this.element = el;
+		this.element = Row.rowTemplate.cloneNode(false) ;
 	}
 	
 	getElement(){
@@ -483,5 +482,12 @@ export default class Row extends CoreFeature{
 		}
 		
 		return this.component;
+	}
+	
+	static createRowTemplate(){
+		const rowTemplate = document.createElement("div");
+		rowTemplate.classList.add("tabulator-row");
+		rowTemplate.setAttribute("role", "row");
+		return rowTemplate;
 	}
 }


### PR DESCRIPTION
### What
- `Row.createElement`: clone a shared template (`cloneNode(false)`) instead of `createElement` + `classList.add` + `setAttribute` per row.
- `RowManager.setActiveRows`: copy with `slice()` instead of `Object.assign([], rows)` (drops a dead double self-assignment).

### Behaviour
Unchanged — full suite green.

### Performance
Baseline `upstream/master` @ `9539446` · branch @ `5f387975`.
- **Isolated** (Node, 250k rows): `setActiveRows` 23.2 → 0.14 ms (**166×**); `Row.createElement` 420 → 249 ms (1.7×).
- **Grid** (headless Chromium, virtual renderer, 20k rows, median of 9): filter **9.2 → 7.1 ms (−23%, 1.3×)** (from `setActiveRows` on the pipeline). Initial render is unchanged — row-create is a small share of a full render.
