### PR TITLE
fix(render): align scrollToRowPosition center/bottom from row offset

### DIFF
--- a/src/js/core/rendering/Renderer.js
+++ b/src/js/core/rendering/Renderer.js
@@ -165,32 +165,28 @@ export default class Renderer extends CoreFeature{
 				//scroll to row
 				this.scrollToRow(row);
 
-				//align to correct position
+				//align to correct position using the row's actual rendered offset
+				//(after scrollToRow the row is not necessarily at the top)
 				switch(position){
 					case "middle":
 					case "center":
-
-						if(this.elementVertical.scrollHeight - this.elementVertical.scrollTop == this.elementVertical.clientHeight){
-							this.elementVertical.scrollTop = this.elementVertical.scrollTop + (rowEl.offsetTop - this.elementVertical.scrollTop) - ((this.elementVertical.scrollHeight - rowEl.offsetTop) / 2);
-						}else{
-							this.elementVertical.scrollTop = this.elementVertical.scrollTop - (this.elementVertical.clientHeight / 2);
-						}
-
+						this.elementVertical.scrollTop = rowEl.offsetTop - (this.elementVertical.clientHeight / 2) + (rowEl.offsetHeight / 2);
 						break;
 
 					case "bottom":
-
-						if(this.elementVertical.scrollHeight - this.elementVertical.scrollTop == this.elementVertical.clientHeight){
-							this.elementVertical.scrollTop = this.elementVertical.scrollTop - (this.elementVertical.scrollHeight - rowEl.offsetTop) + rowEl.offsetHeight;
-						}else{
-							this.elementVertical.scrollTop = this.elementVertical.scrollTop - this.elementVertical.clientHeight + rowEl.offsetHeight;
-						}
-
+						this.elementVertical.scrollTop = rowEl.offsetTop - this.elementVertical.clientHeight + rowEl.offsetHeight;
 						break;
 
 					case "top":
-						this.elementVertical.scrollTop = rowEl.offsetTop;					
+						this.elementVertical.scrollTop = rowEl.offsetTop;
 						break;
+				}
+
+				//keep the virtual renderer's scroll trackers in sync so the next scroll
+				//event doesn't read this manual adjustment as a large jump
+				if(this.vDomScrollPosTop !== undefined){
+					this.vDomScrollPosTop = this.elementVertical.scrollTop;
+					this.vDomScrollPosBottom = this.elementVertical.scrollTop;
 				}
 
 				resolve();

--- a/test/unit/core/rendering/Renderer.spec.js
+++ b/test/unit/core/rendering/Renderer.spec.js
@@ -1,0 +1,63 @@
+import Renderer from "../../../../src/js/core/rendering/Renderer";
+
+// scrollToRowPosition must align center/bottom from the row's actual rendered
+// offsetTop (after scrollToRow the row is not necessarily at the top), and must
+// keep the virtual renderer's scroll trackers in sync with the manual adjustment.
+
+function makeCtx(overrides = {}) {
+	const rowEl = { offsetTop: 500, offsetHeight: 40 };
+	const row = { getElement: () => rowEl };
+	const ctx = {
+		table: { options: {} },
+		elementVertical: { clientHeight: 100, scrollHeight: 1000, scrollTop: 0 },
+		rows: () => [row],
+		scrollToRow: jest.fn(),
+		...overrides,
+	};
+	return { ctx, row, rowEl };
+}
+
+async function scrollTo(ctx, row, position) {
+	await Renderer.prototype.scrollToRowPosition.call(ctx, row, position, true);
+	return ctx.elementVertical.scrollTop;
+}
+
+describe("Renderer.scrollToRowPosition", () => {
+	test("center aligns from offsetTop", async () => {
+		const { ctx, row } = makeCtx();
+		// 500 - 100/2 + 40/2 = 470
+		expect(await scrollTo(ctx, row, "center")).toBe(470);
+	});
+
+	test("bottom aligns from offsetTop", async () => {
+		const { ctx, row } = makeCtx();
+		// 500 - 100 + 40 = 440
+		expect(await scrollTo(ctx, row, "bottom")).toBe(440);
+	});
+
+	test("top uses offsetTop directly", async () => {
+		const { ctx, row } = makeCtx();
+		expect(await scrollTo(ctx, row, "top")).toBe(500);
+	});
+
+	test("updates vDom scroll trackers when present", async () => {
+		const { ctx, row } = makeCtx({ vDomScrollPosTop: 0, vDomScrollPosBottom: 0 });
+		await scrollTo(ctx, row, "center");
+		expect(ctx.vDomScrollPosTop).toBe(470);
+		expect(ctx.vDomScrollPosBottom).toBe(470);
+	});
+
+	test("does not create trackers for the basic renderer", async () => {
+		const { ctx, row } = makeCtx();
+		await scrollTo(ctx, row, "center");
+		expect(ctx.vDomScrollPosTop).toBeUndefined();
+		expect(ctx.vDomScrollPosBottom).toBeUndefined();
+	});
+
+	test("rejects when the row is not in the render list", async () => {
+		const { ctx } = makeCtx();
+		await expect(
+			Renderer.prototype.scrollToRowPosition.call(ctx, { getElement: () => ({}) }, "top", true),
+		).rejects.toBe("Scroll Error - Row not visible");
+	});
+});


### PR DESCRIPTION
### Summary
Fix programmatic `scrollToRow(row, position)` for `center`/`bottom` alignment in the virtual-DOM renderer, and keep the renderer's scroll trackers in sync with the manual adjustment.

### Problem
After `scrollToRow(row)` re-renders with the target row visible, the row is **not necessarily at the top** of the viewport — for rows near the bottom, `_virtualRenderFill` shifts the start position upward to fill the container. The `center`/`bottom` alignment then computed `scrollTop` relative to the *current* `scrollTop`/`clientHeight`, which overshoots when the row isn't at the top (and for bottom rows can scroll past it, detaching it from the virtual DOM).

Separately, the manual `scrollTop` adjustment was not reflected in `vDomScrollPosTop`/`vDomScrollPosBottom`, so the next user scroll computed a large false delta against the stale trackers and triggered an unnecessary full re-render — a visible jump.

### Fix
- Align `center`/`bottom` directly from the row's actual rendered `offsetTop`:
  - center: `offsetTop - clientHeight/2 + offsetHeight/2`
  - bottom: `offsetTop - clientHeight + offsetHeight`
- After alignment, sync `vDomScrollPosTop`/`vDomScrollPosBottom` to the new `scrollTop`, guarded so the basic renderer (no trackers) is unaffected.

### Tests
Adds `test/unit/core/rendering/Renderer.spec.js` covering center/bottom/top alignment, tracker sync, the basic-renderer no-op, and the not-found rejection. Full unit suite green.
