### PR TITLE
fix(render): use correct fallback row index in rerenderRows

### DIFF
--- a/src/js/core/rendering/renderers/VirtualDomVertical.js
+++ b/src/js/core/rendering/renderers/VirtualDomVertical.js
@@ -98,7 +98,9 @@ export default class VirtualDomVertical extends Renderer{
 		}
 
 		if(this.rows().length){
-			this._virtualRenderFill((topRow === false ? this.rows.length - 1 : topRow), true, topOffset || 0);
+			//`this.rows` is the method (arity 0) — `this.rows.length - 1` was
+			//always -1. Fall back to the last display-row index.
+			this._virtualRenderFill((topRow === false ? this.rows().length - 1 : topRow), true, topOffset || 0);
 		}else{
 			this.clear();
 			this.table.rowManager.tableEmpty();

--- a/test/unit/core/VirtualDomVertical.rerender.spec.js
+++ b/test/unit/core/VirtualDomVertical.rerender.spec.js
@@ -1,0 +1,48 @@
+import TabulatorFull from "../../../src/js/core/TabulatorFull";
+
+// Regression: rerenderRows' fallback index was `this.rows.length - 1`, but
+// `this.rows` is the METHOD (arity 0), so the expression was always -1. When the
+// pre-render window scan found no anchor row (stale / out-of-range window), the
+// renderer filled from position -1. Asserted on the argument passed to
+// _virtualRenderFill because jsdom reports the holder as non-visible, so the
+// fill itself is a no-op there.
+describe("VirtualDomVertical rerenderRows fallback index", () => {
+	let el;
+
+	beforeEach(() => {
+		el = document.createElement("div");
+		document.body.appendChild(el);
+	});
+
+	afterEach(() => {
+		el.remove();
+	});
+
+	const data = Array.from({ length: 1000 }, (_, i) => ({ id: i, a: "row " + i }));
+
+	const build = () =>
+		new Promise((resolve) => {
+			const table = new TabulatorFull(el, {
+				height: "300px",
+				data,
+				columns: [{ title: "A", field: "a" }],
+			});
+			table.on("tableBuilt", () => resolve(table));
+		});
+
+	test("fallback passes the last display-row index, not -1", async () => {
+		const table = await build();
+		const renderer = table.rowManager.renderer;
+
+		// Stale / out-of-range rendered window so the anchor scan finds no row and
+		// topRow stays false, exercising the fallback branch.
+		renderer.vDomTop = 99999;
+		renderer.vDomBottom = 99999;
+
+		const spy = jest.spyOn(renderer, "_virtualRenderFill");
+		renderer.rerenderRows(() => {});
+
+		expect(spy).toHaveBeenCalled();
+		expect(spy.mock.calls[0][0]).toBe(data.length - 1); // 999, not -1
+	});
+});


### PR DESCRIPTION
### Problem

`rerenderRows` falls back to the last row index when `topRow === false`, but writes
`this.rows.length - 1`. `this.rows` is a zero-arity **method**, so `.length` is 0 and
the expression is always `-1`.

### Fix

Use `this.rows().length - 1` — the last display-row index.

### Performance

Neutral. 500k rows, K=5, medians (measured together with the follow-up filter-window
fix, see the dependent PR):

| Metric | Before | After |
| --- | --- | --- |
| initial render (ms) | 97.6 | 103.2 |
| initial render, variable heights (ms) | 105.6 | 108.1 |
| fling churn, uniform | 14205 | 14205 |
| fling churn, variable | 3935 | 3935 |
