### PR TITLE
fix(render): clamp vDomTopPad to zero when removing top rows

### DIFF
--- a/src/js/core/rendering/renderers/VirtualDomVertical.js
+++ b/src/js/core/rendering/renderers/VirtualDomVertical.js
@@ -509,6 +509,7 @@ export default class VirtualDomVertical extends Renderer{
 
 		if(paddingAdjust){
 			this.vDomTopPad += paddingAdjust;
+			this.vDomTopPad = Math.max(this.vDomTopPad, 0);
 			this.tableElement.style.paddingTop = this.vDomTopPad + "px";
 			this.vDomScrollPosTop += this.vDomTop ? paddingAdjust : paddingAdjust + this.vDomWindowBuffer;
 		}


### PR DESCRIPTION
### Problem

In `_removeTopRow`, accumulated **actual** row heights can push `vDomTopPad` slightly
negative. That sets a negative `paddingTop` and lets rendered content drift above the
viewport.

### Fix

Clamp `vDomTopPad` to zero after the adjustment. One line.

### A note on test coverage

An e2e test written for this passed **with and without** the fix, so it was deleted
rather than kept as misleading coverage. The failure is a sub-pixel drift that the
existing harness cannot resolve; the reasoning is in the diff comment instead.

### Performance

Neutral. 500k rows, K=5, medians:

| Metric | Before | After |
| --- | --- | --- |
| initial render (ms) | 97.6 | 102.0 |
| initial render, variable heights (ms) | 105.6 | 102.9 |
| fling churn, uniform | 14205 | 14205 |
| fling churn, variable | 3935 | 3935 |
