### PR TITLE
Fix stale cell heights after virtual row recycling

### DIFF
--- a/src/js/core/row/Row.js
+++ b/src/js/core/row/Row.js
@@ -113,6 +113,7 @@ export default class Row extends CoreFeature{
 
 	deinitialize(){
 		this.initialized = false;
+		this.heightInitialized = false;
 	}
 	
 	deinitializeHeight(){

--- a/test/e2e/cell-height-recycle.html
+++ b/test/e2e/cell-height-recycle.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="UTF-8" />
+	<title>Tabulator Virtual Cell Height Recycling Test</title>
+	<link rel="stylesheet" href="../../dist/css/tabulator.min.css" />
+	<script src="../../dist/js/tabulator.js"></script>
+	<style>
+	#test-table {
+		width: 500px;
+	}
+	.tabulator-cell {
+		white-space: normal !important;
+	}
+	</style>
+</head>
+<body>
+	<div id="test-table"></div>
+
+	<script>
+	document.addEventListener("DOMContentLoaded", () => {
+		const metricFields = Array.from(
+			{ length: 32 },
+			(_value, index) => `metric_${index + 1}`,
+		);
+		const data = Array.from({ length: 500 }, (_, index) => {
+			const row = {
+				id: index + 1,
+				name: `Row ${index + 1}`,
+				notes: `Notes for row ${index + 1}`,
+			};
+
+			metricFields.forEach((field, metricIndex) => {
+				row[field] = index * 100 + metricIndex;
+			});
+
+			return row;
+		});
+
+		window.testTable = new Tabulator("#test-table", {
+			data,
+			columns: [
+				{ title: "ID", field: "id", width: 120 },
+				{ title: "Name", field: "name", width: 200 },
+				{ title: "Notes", field: "notes", width: 600 },
+				...metricFields.map((field) => ({ title: field, field, width: 160 })),
+			],
+			height: "300px",
+			rowHeight: 43,
+			layout: "fitData",
+			renderHorizontal: "virtual",
+		});
+	});
+	</script>
+</body>
+</html>

--- a/test/e2e/scroll-jump.spec.ts
+++ b/test/e2e/scroll-jump.spec.ts
@@ -200,6 +200,63 @@ test.describe("Vertical scroll jumping with variable height rows (#3654)", () =>
 	});
 });
 
+test.describe("Cell heights after virtual row recycling", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(`file://${join(__dirname, "cell-height-recycle.html")}`);
+		await page.waitForSelector(".tabulator-row");
+		await page.locator(".tabulator-tableholder").hover();
+	});
+
+	test("normalizes cells recreated after an offscreen column refit", async ({
+		page,
+	}) => {
+		await scrollToBottom(page, 900);
+		await expect(
+			page
+				.locator('.tabulator-cell[tabulator-field="id"]')
+				.filter({ hasText: /^1$/ }),
+		).toHaveCount(0);
+
+		// A column refit makes the horizontal virtual renderer discard cells for
+		// rows outside its current vertical window.
+		await page.evaluate(() => window.testTable.getColumn("name").setWidth(1200));
+
+		// A direct jump takes the vertical renderer's full-fill path when it
+		// recreates the discarded cells.
+		await page.locator(".tabulator-tableholder").evaluate((holder) => {
+			holder.scrollTop = 0;
+			holder.dispatchEvent(new Event("scroll"));
+		});
+
+		await expect
+			.poll(() =>
+				page
+					.locator(".tabulator-row")
+					.first()
+					.locator(".tabulator-cell")
+					.first()
+					.textContent(),
+			)
+			.toBe("1");
+
+		const geometry = await page.locator(".tabulator-row").first().evaluate((row) => ({
+			rowHeight: row.getBoundingClientRect().height,
+			cells: [...row.querySelectorAll(".tabulator-cell")].map((cell) => ({
+				field: cell.getAttribute("tabulator-field"),
+				height: cell.getBoundingClientRect().height,
+				styledHeight: Number.parseFloat((cell as HTMLElement).style.height),
+			})),
+		}));
+
+		expect(geometry.rowHeight).toBe(43);
+		expect(geometry.cells.length).toBeGreaterThan(0);
+		for (const cell of geometry.cells) {
+			expect(cell.height, cell.field).toBe(geometry.rowHeight);
+			expect(cell.styledHeight, cell.field).toBe(geometry.rowHeight);
+		}
+	});
+});
+
 test.describe("Vertical scroll jumping with grouped variable height rows (#3654)", () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto(`file://${join(__dirname, "scroll-jump-group.html")}`);

--- a/test/unit/core/row/Row.spec.js
+++ b/test/unit/core/row/Row.spec.js
@@ -1,0 +1,14 @@
+import Row from "../../../../src/js/core/row/Row.js";
+
+describe("Row", () => {
+	test("deinitialize invalidates the cached row height", () => {
+		const row = Object.create(Row.prototype);
+		row.initialized = true;
+		row.heightInitialized = true;
+
+		row.deinitialize();
+
+		expect(row.initialized).toBe(false);
+		expect(row.heightInitialized).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Invalidate a row’s cached height state whenever the row is deinitialized.

This fixes incorrectly sized cells after virtual rows are recycled, which can leave column borders and cell content such as status indicators only partially rendered.

Example, initial rendering:
<img width="1290" height="352" alt="expected-table-render" src="https://github.com/user-attachments/assets/34030b34-6fad-49c9-a9f6-2b070b0a7980" />

After recycling:
<img width="1295" height="319" alt="broken-table-render" src="https://github.com/user-attachments/assets/6103c790-af6e-41b2-acb7-8305adfcea72" />


## Problem

With horizontal and vertical virtual rendering enabled, the issue can be reproduced by:

1. Scrolling far enough that the original rows leave the rendered window.
2. Triggering a column resize or refit while those rows are offscreen.
3. Jumping directly back to the original rows using the scrollbar.

When the horizontal renderer discards a row’s cells, `Row.deinitialize()` marks the row as uninitialized but leaves `heightInitialized` set to `true`.

When that row is rendered again, new cell elements are created. However, the stale height flag makes Tabulator treat their heights as already normalized, so the configured row height is not applied to the recreated cells. The cells can
consequently render at their natural content height, clipping or misaligning borders, pseudo-elements, and other height-dependent content.

## Fix

Reset `heightInitialized` in `Row.deinitialize()`.

This keeps the row lifecycle consistent: once the existing cell elements have been discarded, their cached height state is no longer valid. The next render therefore measures and normalizes the newly created cells.

## Tests

Added:
- A unit test verifying that `Row.deinitialize()` invalidates both initialization flags.
- A Playwright regression that:
  - moves the original rows outside the virtual rendering window,
  - resizes a column while they are offscreen,
  - jumps directly back to the first row,
  - verifies that every recreated cell receives the configured row height.